### PR TITLE
Don't swallow error for modal

### DIFF
--- a/src/components/TransactionModal/TransactionModal.tsx
+++ b/src/components/TransactionModal/TransactionModal.tsx
@@ -92,7 +92,7 @@ const TransactionModal = <P, T extends string>({
       setIsLoading(true);
       const result = await tx.wait();
 
-      // resetModal();
+      resetModal();
       if (result.status) {
         setSuccessModalText(text.successText || 'Success');
       } else {


### PR DESCRIPTION
Fixes error being swallowed for transaction modals that use `ModalInput` component and resets the loading state on failure