### PR TITLE
fix async rendering in accept offer

### DIFF
--- a/src/pages/plans/OfferMarketplace/CheckList.tsx
+++ b/src/pages/plans/OfferMarketplace/CheckList.tsx
@@ -160,7 +160,7 @@ export const CheckList: React.VFC<ICheckList> = ({
         {
           title: t('offerMarket.acceptModal.dailyRewards'),
           requiredValue: `${REQUIRED_DAILY_REWARD_CAP} SQT`,
-          value: dailyRewardCapacity ? `${dailyRewardCapacity} SQT` : undefined,
+          value: `${dailyRewardCapacity} SQT`,
           passCheck: REQUIRED_DAILY_REWARD_CAP <= dailyRewardCapacity,
           errorMsg: t('offerMarket.acceptModal.dailyRewardsError'),
         },


### PR DESCRIPTION
This will ensure it will show a spinner and no error message before async data has finished fetching.
The actual problem of this ticket was solved by setting the threshold.

https://onfinality.atlassian.net/jira/software/projects/SQN/boards/14?selectedIssue=SQN-792