### PR TITLE
SQN-804: setInterval for minutes left

### DIFF
--- a/src/components/CurEra/CurEra.tsx
+++ b/src/components/CurEra/CurEra.tsx
@@ -24,6 +24,12 @@ const getEraProgress = (now: Date, estEndTime: Date, startTime: Date): number =>
 export const CurEra: React.FC = () => {
   const { currentEra } = useEra();
   const { t } = useTranslation();
+  const [now, setNow] = React.useState<Date>(new Date());
+
+  React.useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 5000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <>
@@ -32,7 +38,6 @@ export const CurEra: React.FC = () => {
         error: (e) => <Typography>{`${t('era.currentEra')}: -`}</Typography>,
         data: (era) => {
           if (!era) return null;
-          const now = new Date();
           const eraHours = `${era.period / 3600}`;
           const mNow = moment(now);
 


### PR DESCRIPTION
Can still change interval for updating `now` date variable. Probably could update to every 1 second.
https://onfinality.atlassian.net/jira/software/projects/SQN/boards/14?assignee=614cf62d071141006ae08a3a&selectedIssue=SQN-804