### PR TITLE
feat: add order/filter features to TopIdnexers

### DIFF
--- a/src/pages/staking/Indexers/AllIndexers/IndexerList/IndexerList.tsx
+++ b/src/pages/staking/Indexers/AllIndexers/IndexerList/IndexerList.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import i18next from 'i18next';
-import { extractPercentage, formatEther, renderAsync } from '../../../../../utils';
+import { extractPercentage, formatEther, getOrderedAccounts, renderAsync } from '../../../../../utils';
 import { CurrentEraValue } from '../../../../../hooks/useEraValue';
 import { GetIndexers_indexers_nodes as Indexer } from '../../../../../__generated__/registry/GetIndexers';
 import { useDelegation, useIndexer, useWeb3 } from '../../../../../containers';
@@ -308,9 +308,7 @@ export const IndexerList: React.VFC<props> = ({ indexers, onLoadMore, totalCount
     return { ...indexer, commission, totalStake };
   });
 
-  const orderedIndexerList = sortedIndexerList.sort((indexerA, indexerB) =>
-    indexerA.id === account ? -1 : indexerB.id === account ? 1 : 0,
-  );
+  const orderedIndexerList = getOrderedAccounts(sortedIndexerList, 'id', account);
 
   /**
    * Sort Indexers logic end

--- a/src/pages/staking/Indexers/TopIndexers/TopIndexersList.tsx
+++ b/src/pages/staking/Indexers/TopIndexers/TopIndexersList.tsx
@@ -14,6 +14,7 @@ import { TableTitle } from '../../../../components/TableTitle';
 import { useWeb3 } from '../../../../containers';
 import styles from './TopIndexersList.module.css';
 import { GetTopIndexers_indexerPrograms } from '../../../../__generated__/excellentIndexers/GetTopIndexers';
+import { getOrderedAccounts } from '../../../../utils';
 
 const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>['columns'] => [
   {
@@ -37,6 +38,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     ),
     dataIndex: 'totalPoints',
     render: (ranking) => <TableText>{ranking}</TableText>,
+    sorter: (a, b) => a.totalPoints - b.totalPoints,
   },
   {
     title: (
@@ -48,6 +50,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     ),
     dataIndex: 'uptime',
     render: (upTime) => <TableText>{`${upTime * 100} %`}</TableText>,
+    sorter: (a, b) => a.uptime - b.uptime,
   },
   {
     title: (
@@ -59,6 +62,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     ),
     dataIndex: 'ownStaked',
     render: (ownStake) => <TableText>{`${ownStake * 100} %`}</TableText>,
+    sorter: (a, b) => a.ownStaked - b.ownStaked,
   },
   {
     title: (
@@ -70,6 +74,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     ),
     dataIndex: 'delegated',
     render: (delegated) => <TableText>{`${delegated * 100} %`}</TableText>,
+    sorter: (a, b) => a.delegated - b.delegated,
   },
   {
     title: (
@@ -83,6 +88,20 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     render: (eraRewardsCollection) => (
       <TableText>{i18next.t(eraRewardsCollection === 1 ? 'general.frequent' : 'general.infrequent')}</TableText>
     ),
+    filters: [
+      {
+        text: i18next.t('general.frequent'),
+        value: 1,
+      },
+      {
+        text: i18next.t('general.infrequent'),
+        value: 0,
+      },
+    ],
+    onFilter: (value, record) => {
+      if (value === 1) return record.rewardCollection >= value;
+      return record.rewardCollection < 1;
+    },
   },
   // {
   //   title: (
@@ -105,6 +124,20 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     ),
     dataIndex: 'sslEnabled',
     render: (enableSSL) => <TableText>{i18next.t(enableSSL ? 'general.enabled' : 'general.disabled')}</TableText>,
+    filters: [
+      {
+        text: i18next.t('general.enabled'),
+        value: true,
+      },
+      {
+        text: i18next.t('general.disabled'),
+        value: false,
+      },
+    ],
+    onFilter: (value, record) => {
+      if (value) return record.sslEnabled;
+      return !record.sslEnabled;
+    },
   },
   {
     title: (
@@ -118,11 +151,27 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     render: (socialCredibility) => (
       <TableText>{i18next.t(socialCredibility ? 'general.enabled' : 'general.disabled')}</TableText>
     ),
+    filters: [
+      {
+        text: i18next.t('general.enabled'),
+        value: true,
+      },
+      {
+        text: i18next.t('general.disabled'),
+        value: false,
+      },
+    ],
+    onFilter: (value, record) => {
+      if (value) return record.socialCredibility;
+      return !record.socialCredibility;
+    },
   },
   {
     title: <TableTitle title={i18next.t('indexer.action')} />,
-    dataIndex: 'indexer',
+    dataIndex: 'id',
+    align: 'center',
     render: (id: string) => {
+      console.log('id', id);
       if (id === account) return <Typography> - </Typography>;
       return <DoDelegate indexerAddress={id} variant="textBtn" />;
     },
@@ -138,6 +187,8 @@ export const TopIndexerList: React.VFC<props> = ({ indexers, onLoadMore }) => {
   const { t } = useTranslation();
   const { account } = useWeb3();
   //   const history = useHistory();
+
+  const orderedIndexerList = getOrderedAccounts(indexers.slice(), 'id', account);
 
   const SearchAddress = () => (
     <div className={styles.indexerSearch}>
@@ -162,7 +213,7 @@ export const TopIndexerList: React.VFC<props> = ({ indexers, onLoadMore }) => {
 
       <AntDTable
         customPagination
-        tableProps={{ columns, rowKey: 'id', dataSource: [...indexers] }}
+        tableProps={{ columns, rowKey: 'id', dataSource: [...orderedIndexerList] }}
         // paginationProps={{
         //   total: searchedIndexer ? searchedIndexer.length : totalCount,
         //   onChange: (page, pageSize) => {

--- a/src/utils/getOrderedAccounts.ts
+++ b/src/utils/getOrderedAccounts.ts
@@ -1,0 +1,17 @@
+// Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import * as moment from 'moment';
+import momentDurationFormatSetup from 'moment-duration-format';
+momentDurationFormatSetup(moment);
+
+export const getOrderedAccounts = (
+  accounts: Array<any>,
+  key: string,
+  targetAccount: string | null | undefined,
+): Array<any> => {
+  if (!targetAccount) return accounts;
+  return accounts.sort((accountA, accountB) =>
+    accountA[key] === targetAccount ? -1 : accountB[key] === targetAccount ? 1 : 0,
+  );
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -17,6 +17,7 @@ export * from './localStorage';
 export * from './colors';
 export * from './constants';
 export * from './USDC';
+export * from './getOrderedAccounts';
 
 export function truncateAddress(address: string): string {
   if (!address) {


### PR DESCRIPTION
## Description

feat: add order/filter features to TopIdnexers

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvements (ie: code cleaning or remove unused codes or performance issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

- reorder with `YouOwnAccount` at first Row
- add `order` feature to TopIndexers
- add `filter` feature to TopIndexers

## UI Changes

Add before and after changes for UI if needed.

|before|after|
|-|-|
|<img width="1509" alt="Screen Shot 2022-10-19 at 5 49 55 PM" src="https://user-images.githubusercontent.com/14360297/196600546-1fab871f-9e11-4a6a-82ee-0162a26d7cc8.png">|<img width="1509" alt="Screen Shot 2022-10-19 at 5 47 30 PM" src="https://user-images.githubusercontent.com/14360297/196600571-9878c165-f37a-41ba-b893-9b84ce11af2e.png">|

