### PR TITLE
disable default sorter Tooltip

### DIFF
--- a/src/pages/staking/Indexers/TopIndexers/TopIndexersList.tsx
+++ b/src/pages/staking/Indexers/TopIndexers/TopIndexersList.tsx
@@ -39,6 +39,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     dataIndex: 'totalPoints',
     render: (ranking) => <TableText>{ranking.toFixed(2)}</TableText>,
     sorter: (a, b) => a.totalPoints - b.totalPoints,
+    showSorterTooltip: false,
   },
   {
     title: (
@@ -51,6 +52,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     dataIndex: 'uptime',
     render: (upTime) => <TableText>{`${mulToPercentage(upTime)} %`}</TableText>,
     sorter: (a, b) => a.uptime - b.uptime,
+    showSorterTooltip: false,
   },
   {
     title: (
@@ -63,6 +65,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     dataIndex: 'ownStaked',
     render: (ownStake) => <TableText>{`${mulToPercentage(ownStake)} %`}</TableText>,
     sorter: (a, b) => a.ownStaked - b.ownStaked,
+    showSorterTooltip: false,
   },
   {
     title: (
@@ -75,6 +78,7 @@ const getColumns = (account: string): TableProps<GetTopIndexers_indexerPrograms>
     dataIndex: 'delegated',
     render: (delegated) => <TableText>{`${mulToPercentage(delegated)} %`}</TableText>,
     sorter: (a, b) => a.delegated - b.delegated,
+    showSorterTooltip: false,
   },
   {
     title: (


### PR DESCRIPTION
## Description

Ticket: [SQN-984](https://onfinality.atlassian.net/browse/SQN-984?atlOrigin=eyJpIjoiYmM4NzQzMGQ2NThmNDZiMzk0Yjg0YTBlZWY0Y2ViYTgiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- set SorterTooltip to false

## UI Changes

Add before and after changes for UI if needed.

|before|after|
|-|-|
|
<img width="385" alt="Screen Shot 2022-10-25 at 2 10 58 PM" src="https://user-images.githubusercontent.com/92004774/197662346-16498f03-0a7c-4c8d-99ef-3bee284d0bad.png">
|<img width="448" alt="Screen Shot 2022-10-25 at 2 09 05 PM" src="https://user-images.githubusercontent.com/92004774/197662426-973e9bb7-b4cb-42d8-8da4-84818b36bc85.png">)|
