### PR TITLE
feat: setCommisionRate & improve useSortedIndexer

### DIFF
--- a/src/hooks/useSortedIndexer.tsx
+++ b/src/hooks/useSortedIndexer.tsx
@@ -1,7 +1,9 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useDelegation, useEra, useIndexer } from '../containers';
+import { useGetDelegationQuery, useGetIndexerQuery } from '@subql/react-hooks';
+import { useEra } from '../containers';
+import { SUB_DELEGATIONS, SUB_INDEXERS } from '../containers/IndexerRegistryProjectSub';
 import {
   AsyncData,
   convertBigNumberToNumber,
@@ -60,8 +62,32 @@ export interface UseSortedIndexerReturn {
 
 export function useSortedIndexer(account: string): AsyncData<UseSortedIndexerReturn> {
   const { currentEra } = useEra();
-  const indexerData = useIndexer({ address: account });
-  const indexerDelegation = useDelegation(account, account);
+  const indexerQueryParams = { address: account ?? '' };
+  const indexerData = useGetIndexerQuery({ variables: indexerQueryParams });
+  const delegationQueryParams = { id: `${account ?? ''}:${account}` };
+  const indexerDelegation = useGetDelegationQuery({ variables: delegationQueryParams });
+
+  indexerData.subscribeToMore({
+    document: SUB_INDEXERS,
+    variables: { id: account ?? '' },
+    updateQuery: (prev, { subscriptionData }) => {
+      if (subscriptionData.data) {
+        indexerData.refetch(indexerQueryParams);
+      }
+      return prev;
+    },
+  });
+
+  indexerDelegation.subscribeToMore({
+    document: SUB_DELEGATIONS,
+    variables: delegationQueryParams,
+    updateQuery: (prev, { subscriptionData }) => {
+      if (subscriptionData.data) {
+        indexerDelegation.refetch(delegationQueryParams);
+      }
+      return prev;
+    },
+  });
 
   const { loading, error, data } = mergeAsync(currentEra, indexerData, indexerDelegation);
 

--- a/src/i18n/en/indexer.ts
+++ b/src/i18n/en/indexer.ts
@@ -42,7 +42,7 @@ const translation = {
     updateCommissionRate: 'Change commission rate',
     setNewCommissionRate: 'Set new commission rate',
     disabledSetCommissionBeforeRewardClaim: `You can't change commission rate until you collect all early era's rewards. Please check the indexer admin app to ensure the lastClaimedEra = ‘currentEra - 1’.`,
-    newRateValidNext2Era: 'Once confirm, the new rate will take 2 full eras to be effective.',
+    newRateValidNext2Era: 'Once confirmed, the new commission rate will take 2 full eras to take effect.',
     enterCommissionRate: 'Enter the commission rate',
     currentRate: 'Current commission rate',
     confirmRate: 'Confirm Rate',

--- a/src/pages/delegator/DoDelegate/DoDelegate.tsx
+++ b/src/pages/delegator/DoDelegate/DoDelegate.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import assert from 'assert';
 import { formatEther, parseEther } from '@ethersproject/units';
 import { useTranslation } from 'react-i18next';
-import { useContracts, useDelegation, useEra, useIndexer, useSQToken, useWeb3 } from '../../../containers';
+import { useContracts, useEra, useSQToken, useWeb3 } from '../../../containers';
 import {
   tokenApprovalModalText,
   ModalApproveToken,
@@ -19,7 +19,7 @@ import { Spinner, Typography } from '@subql/react-ui';
 import { mapEraValue, parseRawEraValue } from '../../../hooks/useEraValue';
 import { DelegateForm } from './DelegateFrom';
 import { BigNumber } from 'ethers';
-import { useGetIndexerQuery } from '@subql/react-hooks';
+import { useGetDelegationQuery, useGetIndexerQuery } from '@subql/react-hooks';
 
 const getModalText = (requireClaimIndexerRewards = false, requireTokenApproval = false, t: any) => {
   if (requireClaimIndexerRewards) return claimIndexerRewardsModalText;
@@ -49,7 +49,7 @@ export const DoDelegate: React.VFC<DoDelegateProps> = ({ indexerAddress, variant
   const { stakingAllowance } = useSQToken();
   const requireTokenApproval = stakingAllowance?.data?.isZero();
   const rewardClaimStatus = useRewardCollectStatus(indexerAddress);
-  const delegation = useDelegation(account ?? '', indexerAddress);
+  const delegation = useGetDelegationQuery({ variables: { id: `${account ?? ''}:${indexerAddress}` } });
   const indexer = useGetIndexerQuery({ variables: { address: account ?? '' } });
 
   const handleClick = async ({ input, delegator }: { input: number; delegator?: string }) => {

--- a/src/pages/indexer/MyStaking/MyStaking.module.css
+++ b/src/pages/indexer/MyStaking/MyStaking.module.css
@@ -26,9 +26,16 @@
   flex-direction: column;
 }
 
+.stakingHeader {
+  margin: 1.25rem 0;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
 .stakingAmount {
   width: 280px;
-  margin: 1.25rem 0;
 }
 
 .tabList {

--- a/src/pages/indexer/MyStaking/MyStaking.tsx
+++ b/src/pages/indexer/MyStaking/MyStaking.tsx
@@ -11,8 +11,8 @@ import { useTranslation } from 'react-i18next';
 import { useIsIndexer, useSortedIndexer } from '../../../hooks';
 import { mergeAsync, renderAsync, ROUTES, TOKEN, truncFormatEtherStr } from '../../../utils';
 import { Indexing, NotRegisteredIndexer } from './Indexing';
+import { SetCommissionRate } from './SetCommissionRate';
 
-// TODO: mergeAsync issue with array loading
 export const MyStaking: React.VFC = () => {
   const { t } = useTranslation();
   const { account } = useWeb3();
@@ -46,10 +46,16 @@ export const MyStaking: React.VFC = () => {
 
             return (
               <>
-                <div className={styles.stakingAmount}>
-                  <Card title={t('indexer.stakingAmountTitle')} value={`${sortedTotalStaking} ${TOKEN}`} />
+                <div className={styles.stakingHeader}>
+                  <div className={styles.stakingAmount}>
+                    <Card title={t('indexer.stakingAmountTitle')} value={`${sortedTotalStaking} ${TOKEN}`} />
+                  </div>
+                  <div className={styles.stakingActions}>
+                    <SetCommissionRate />
+                  </div>
                 </div>
-                <Indexing tableData={sortedIndexer} indexer={account ?? ''} />
+
+                <Indexing tableData={s} />
               </>
             );
           },

--- a/src/pages/indexer/MyStaking/SetCommissionRate/SetCommissionRate.tsx
+++ b/src/pages/indexer/MyStaking/SetCommissionRate/SetCommissionRate.tsx
@@ -1,0 +1,79 @@
+// Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import assert from 'assert';
+import { useTranslation } from 'react-i18next';
+import { useContracts, useWeb3 } from '../../../../containers';
+import TransactionModal from '../../../../components/TransactionModal';
+import { useRewardCollectStatus } from '../../../../hooks/useRewardCollectStatus';
+import { mergeAsync, renderAsyncArray } from '../../../../utils';
+import { Spinner, Typography } from '@subql/react-ui';
+import { COMMISSION_DIV_UNIT, useCommissionRate } from '../../../../hooks/useCommissionRate';
+import { claimIndexerRewardsModalText, ModalClaimIndexerRewards } from '../../../../components';
+
+const getModalText = (requireClaimIndexerRewards = false, commissionRate: string | undefined, t: any) => {
+  if (requireClaimIndexerRewards) return claimIndexerRewardsModalText;
+
+  return {
+    title: t('indexer.updateCommissionRate'),
+    steps: [t('indexer.setNewCommissionRate'), t('indexer.confirmOnMetamask')],
+    description: t('indexer.newRateValidNext2Era'),
+    inputTitle: t('indexer.enterCommissionRate'),
+    inputBottomText: `${t('indexer.currentRate')}: ${commissionRate ?? 0}%`,
+    submitText: t('indexer.confirmRate'),
+    failureText: `Sorry, the commission update operation has failed.`,
+  };
+};
+
+export const SetCommissionRate: React.VFC = () => {
+  const pendingContracts = useContracts();
+  const { t } = useTranslation();
+  const { account } = useWeb3();
+
+  const rewardClaimStatus = useRewardCollectStatus(account || '');
+  const commissionRate = useCommissionRate(account);
+
+  const handleClick = async (amount: string) => {
+    const contracts = await pendingContracts;
+    assert(contracts, 'Contracts not available');
+    return contracts.staking.setCommissionRate(Math.floor(parseInt(amount, 10) * COMMISSION_DIV_UNIT));
+  };
+
+  return renderAsyncArray(mergeAsync(rewardClaimStatus, commissionRate), {
+    error: (error) => <Typography>{`Failed to get indexer info: ${error.message}`}</Typography>,
+    loading: () => <Spinner />,
+    empty: () => <></>,
+    data: (data) => {
+      const [indexerRewards, sortedCommissionRate] = data;
+
+      const requireClaimIndexerRewards = !indexerRewards?.hasClaimedRewards;
+      const modalText = getModalText(requireClaimIndexerRewards, sortedCommissionRate?.toString(), t);
+
+      return (
+        <TransactionModal
+          text={modalText}
+          actions={[
+            {
+              label: t('indexer.updateCommissionRate'),
+              key: 'commission',
+            },
+          ]}
+          inputParams={{
+            min: 0,
+            max: 100,
+            showMaxButton: false,
+            unit: '%',
+          }}
+          onClick={handleClick}
+          onSuccess={() => commissionRate.refetch(true)}
+          renderContent={(onSubmit, _, loading) => {
+            if (requireClaimIndexerRewards) {
+              return <ModalClaimIndexerRewards onSuccess={() => rewardClaimStatus.refetch()} indexer={account ?? ''} />;
+            }
+          }}
+        />
+      );
+    },
+  });
+};

--- a/src/pages/indexer/MyStaking/SetCommissionRate/index.ts
+++ b/src/pages/indexer/MyStaking/SetCommissionRate/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './SetCommissionRate';


### PR DESCRIPTION
## Description

- Replace `useSortedIndexer` with `client-sdk-query`
- Apply `subcribeToMore` for data subscription 
- Add `setComiisionRate` feature and improvement to myStaking page

Ticket: [SQN-1103](https://onfinality.atlassian.net/browse/SQN-1103)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvements (ie: code cleaning or remove unused codes or performance issue)


## UI Changes

|setComiisionRate|
|-|
|<img width="1449" alt="Screen Shot 2023-02-09 at 5 24 40 PM" src="https://user-images.githubusercontent.com/14360297/217718626-97283302-104f-4d2b-858d-126a7c8d8a1b.png">|

