### PR TITLE
add a stopPropagation call inside the handleClick function that is tr…

### DIFF
--- a/src/components/Copy/Copy.tsx
+++ b/src/components/Copy/Copy.tsx
@@ -26,7 +26,8 @@ type Props = {
 const Copy: React.FC<Props> = ({ value, className, iconClassName, children, iconSize, position = 'flex-center' }) => {
   const [icon, setIcon] = React.useState<boolean>(false);
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.stopPropagation();
     setIcon(true);
     if (value) {
       navigator.clipboard.writeText(value);
@@ -36,7 +37,7 @@ const Copy: React.FC<Props> = ({ value, className, iconClassName, children, icon
   };
 
   return (
-    <div className={position} onClick={handleClick}>
+    <div className={position} onClick={(e) => handleClick(e)}>
       {children}
       <div className={clsx(styles.container, className)}>
         <div className={clsx(styles.copy, iconClassName)}>


### PR DESCRIPTION

## Description
add a stopPropagation call inside the handleClick function that is triggered by the copy icon.

## Type of change

Please delete options that are not relevant.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvements (ie: code cleaning or remove unused codes or performance issue)


