### PR TITLE
chore: arrange env

### DIFF
--- a/src/config/sentryConf.ts
+++ b/src/config/sentryConf.ts
@@ -26,9 +26,10 @@ Sentry.init({
 
     return event;
   },
+  // this env set on Github workflow.
   dsn: import.meta.env.VITE_SENTRY_DSN,
   integrations: [new BrowserTracing()],
-  environment: import.meta.env.NODE_ENV,
+  environment: import.meta.env.MODE,
   // Set tracesSampleRate to 1.0 to capture 100%
   tracesSampleRate: 1.0,
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ const tagManagerArgs = {
   gtmId: 'G-DK4PX8F61X',
 };
 
-const isProd = import.meta.env.NODE_ENV === 'production';
+const isProd = import.meta.env.PROD;
 isProd && TagManager.initialize(tagManagerArgs);
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/utils/TalismanConnector.ts
+++ b/src/utils/TalismanConnector.ts
@@ -25,7 +25,7 @@ export type TalismanWindow = Window &
 // prevents error with SSR
 const talismanWindow = typeof window !== 'undefined' ? (window as TalismanWindow) : ({} as TalismanWindow);
 
-const __DEV__ = import.meta.env.NODE_ENV !== 'production';
+const __DEV__ = import.meta.env.DEV;
 
 function parseSendReturn(sendReturn: SendReturnResult | SendReturn): any {
   return sendReturn.hasOwnProperty('result') ? sendReturn.result : sendReturn;


### PR DESCRIPTION
## Description

`NODE_ENV` is invalid on vite.

`PROD`, `DEV`, `MODE` are default vite environments.

https://vitejs.dev/guide/env-and-mode.html

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## UI Changes

<img width="323" alt="微信截图_20230619175315" src="https://github.com/subquery/network-explorer/assets/10172415/c0c06d32-e7ac-4976-a2fe-de965c6869e4">

<img width="373" alt="微信截图_20230619175410" src="https://github.com/subquery/network-explorer/assets/10172415/85a66252-7ea2-490d-b5d0-7c1c15fa3305">
