### PR TITLE
feat: handle error

### DIFF
--- a/src/components/DeploymentInfo/DeploymentInfo.tsx
+++ b/src/components/DeploymentInfo/DeploymentInfo.tsx
@@ -11,7 +11,7 @@ import { useIPFS, useProjectMetadata } from '../../containers';
 import { useAsyncMemo } from '../../hooks';
 import { getDeploymentMetadata } from '../../hooks/useDeploymentMetadata';
 import { ProjectMetadata } from '../../models';
-import { getTrimmedStr, renderAsync } from '../../utils';
+import { getTrimmedStr, parseError, renderAsync } from '../../utils';
 import Copy from '../Copy';
 import IPFSImage from '../IPFSImage';
 import { TableText } from '../TableText';
@@ -73,7 +73,7 @@ export const DeploymentMeta: React.FC<{ deploymentId: string; projectMetadata?: 
 
   return renderAsync(metadata, {
     loading: () => <Spinner />,
-    error: (e) => <Typography>{`Failed to load project info: ${e}`}</Typography>,
+    error: (e) => <Typography>{`Failed to load project info: ${parseError(e)}`}</Typography>,
     data: (projectMeta) => {
       if (!projectMeta) {
         return <Typography>Project metadata not found</Typography>;

--- a/src/components/ModalApproveToken/ModalApproveToken.tsx
+++ b/src/components/ModalApproveToken/ModalApproveToken.tsx
@@ -79,7 +79,6 @@ export const ModalApproveToken: React.FC<ModalApproveTokenProps> = ({
         onSubmit && onSubmit();
       }
     } catch (error) {
-      console.error('ModalApproveToken', error);
       setError(parseError(error));
     } finally {
       setIsLoading(false);

--- a/src/components/ModalClaimIndexerRewards/ModalClaimIndexerRewards.tsx
+++ b/src/components/ModalClaimIndexerRewards/ModalClaimIndexerRewards.tsx
@@ -50,7 +50,6 @@ export const ModalClaimIndexerRewards: React.FC<IModalClaimIndexerRewards> = ({
         onFail && onFail();
       }
     } catch (error) {
-      console.error('onClaimIndexerRewards', error);
       setError(parseError(error));
     } finally {
       setIsLoading(false);

--- a/src/components/ProjectEdit/ProjectEdit.tsx
+++ b/src/components/ProjectEdit/ProjectEdit.tsx
@@ -7,7 +7,7 @@ import { Button, Typography } from '@subql/components';
 import { Form, Formik } from 'formik';
 
 import { FormProjectMetadata, projectMetadataSchema, ProjectWithMetadata } from '../../models';
-import { isEthError } from '../../utils';
+import { isEthError, parseError } from '../../utils';
 import ImageInput from '../ImageInput';
 import { FTextInput } from '..';
 import styles from './ProjectEdit.module.css';
@@ -30,7 +30,7 @@ const ProjectEdit: React.FC<Props> = (props) => {
         setSubmitError(t('errors.transactionRejected'));
         return;
       }
-      setSubmitError((e as Error).message);
+      setSubmitError(parseError(e));
     }
   };
 

--- a/src/components/TransactionModal/TransactionModal.tsx
+++ b/src/components/TransactionModal/TransactionModal.tsx
@@ -128,7 +128,6 @@ const TransactionModal = <P, T extends string>({
         throw new Error(text.failureText);
       }
     } catch (error) {
-      console.error('TxAction error', error);
       openNotificationWithIcon({
         type: NotificationType.ERROR,
         title: 'Failure',

--- a/src/containers/Web3.tsx
+++ b/src/containers/Web3.tsx
@@ -6,6 +6,7 @@ import { networks } from '@subql/contract-sdk';
 import keplerJSON from '@subql/contract-sdk/publish/kepler.json';
 import testnetJSON from '@subql/contract-sdk/publish/testnet.json';
 import { SQNetworks } from '@subql/network-config';
+import { parseError } from '@utils/parseError';
 import { useWeb3React, Web3ReactProvider } from '@web3-react/core';
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
 import { InjectedConnector } from '@web3-react/injected-connector';
@@ -124,14 +125,12 @@ export const handleSwitchNetwork = async (ethWindowObj = window?.ethereum) => {
       params: [{ chainId: `0x${Number(defaultChainId).toString(16)}` }],
     });
   } catch (e: any) {
-    console.log('e:', e);
+    parseError(e);
     if (e?.code === 4902) {
       await ethWindowObj.request({
         method: ethMethods.addChain,
         params: [networks[SUPPORTED_NETWORK]],
       });
-    } else {
-      console.log('Switch Ethereum network failed', e);
     }
   }
 };
@@ -151,7 +150,7 @@ export const useConnectNetwork = () => {
         setEthWindowObj(connector.windowObj);
         await activate(connector.connector);
       } catch (e) {
-        console.log('Failed to activate wallet', e);
+        parseError(e);
       }
     },
     [account, deactivate, setEthWindowObj, activate],

--- a/src/hooks/useInitContracts.ts
+++ b/src/hooks/useInitContracts.ts
@@ -6,6 +6,7 @@ import { useWeb3 } from '@containers';
 import { NETWORK_NAME } from '@containers/Web3';
 import { ContractSDK } from '@subql/contract-sdk';
 import { ContractClient } from '@subql/network-clients';
+import { parseError } from '@utils';
 
 import { useWeb3Store } from 'src/stores';
 
@@ -29,7 +30,7 @@ export function useInitContracts(): { loading: boolean } {
 
           console.log('Contract Instance Initial', contractInstance);
         } catch (error) {
-          console.error('Failed to init contracts', error);
+          parseError(error);
         }
       }
     }

--- a/src/hooks/useSwapData.tsx
+++ b/src/hooks/useSwapData.tsx
@@ -39,7 +39,6 @@ export function useSwapRate(orderId: string | undefined): AsyncMemoReturn<number
   const { contracts } = useWeb3Store();
   return useAsyncMemo(async () => {
     if (!orderId) return 0;
-
     assert(contracts, 'Contracts not available');
     const { amountGive, amountGet, tokenGet, tokenGive } = await contracts.permissionedExchange.orders(orderId);
     return formatToken(amountGive, tokenDecimals[tokenGive]) / formatToken(amountGet, tokenDecimals[tokenGet]);

--- a/src/pages/account/Rewards/ClaimRewards.tsx
+++ b/src/pages/account/Rewards/ClaimRewards.tsx
@@ -39,18 +39,9 @@ export const ClaimRewards: React.FC<Props> = ({ account, indexers, totalUnclaime
   const handleClick = async () => {
     assert(contracts, 'Contracts not available');
 
-    try {
-      const pendingTx = contracts.rewardsHelper.batchClaim(account, indexers);
-      pendingTx.then((tx) => tx.wait()).then(() => onClaimed?.());
-      return pendingTx;
-    } catch (e: any) {
-      throw new Error(
-        `${e} other information: ${JSON.stringify({
-          account,
-          indexers,
-        })}`,
-      );
-    }
+    const pendingTx = contracts.rewardsHelper.batchClaim(account, indexers);
+    pendingTx.then((tx) => tx.wait()).then(() => onClaimed?.());
+    return pendingTx;
   };
 
   return (

--- a/src/pages/consumer/MyFlexPlans/TerminateFlexPlan.tsx
+++ b/src/pages/consumer/MyFlexPlans/TerminateFlexPlan.tsx
@@ -11,7 +11,7 @@ import { BigNumber } from 'ethers';
 import { AppTypography, SummaryList } from '../../../components';
 import TransactionModal from '../../../components/TransactionModal';
 import { useWeb3 } from '../../../containers';
-import { getAuthReqHeader, TOKEN } from '../../../utils';
+import { getAuthReqHeader, parseError, TOKEN } from '../../../utils';
 import { requestConsumerHostToken } from '../../../utils/eip721SignTokenReq';
 import { formatEther } from '../../../utils/numberFormatters';
 import styles from './MyFlexPlans.module.css';
@@ -38,7 +38,7 @@ async function terminatePlan(flexPlanId: string, account: string, library: Web3P
 
     return { data: sortedResponse };
   } catch (error) {
-    console.error(`Failed to terminate flex plan. ${error}`);
+    parseError(error);
     return { error };
   }
 }

--- a/src/pages/consumer/MyOffers/CreateOffer/Summary/Summary.tsx
+++ b/src/pages/consumer/MyOffers/CreateOffer/Summary/Summary.tsx
@@ -81,7 +81,6 @@ export const Summary: React.FC = () => {
         });
       });
     } catch (error) {
-      console.error('handleOfferCreate error', error);
       openNotificationWithIcon({
         type: NotificationType.ERROR,
         title: 'Offer created Failed',

--- a/src/pages/explorer/FlexPlans/PurchaseFlexPlan.tsx
+++ b/src/pages/explorer/FlexPlans/PurchaseFlexPlan.tsx
@@ -18,7 +18,7 @@ import { BillingExchangeModal } from '../../../components/BillingTransferModal';
 import TransactionModal from '../../../components/TransactionModal';
 import { useConsumerOpenFlexPlans, useWeb3 } from '../../../containers';
 import { IIndexerFlexPlan } from '../../../hooks';
-import { formatEther, getAuthReqHeader, getCapitalizedStr, POST, renderAsync, TOKEN } from '../../../utils';
+import { formatEther, getAuthReqHeader, getCapitalizedStr, parseError, POST, renderAsync, TOKEN } from '../../../utils';
 import { requestConsumerHostToken } from '../../../utils/eip721SignTokenReq';
 
 async function purchasePlan(amount: string, period: number, deploymentIndexer: number, authToken: string) {
@@ -44,7 +44,7 @@ async function purchasePlan(amount: string, period: number, deploymentIndexer: n
 
     return { data: sortedResponse };
   } catch (error) {
-    console.error(`Failed to purchase flex plan. ${error}`);
+    parseError(error);
     return { error: `${error ?? 'Failed to purchase flex plan.'}` };
   }
 }

--- a/src/pages/explorer/Project/Project.tsx
+++ b/src/pages/explorer/Project/Project.tsx
@@ -94,7 +94,7 @@ const ProjectInner: React.FC = () => {
             indexer: indexer.indexerId,
           });
         } catch (error) {
-          console.error(parseError(error));
+          parseError(error);
         }
 
         if (!indexerMeta) return;

--- a/src/pages/studio/Create/Create.tsx
+++ b/src/pages/studio/Create/Create.tsx
@@ -12,7 +12,7 @@ import { Form, Formik } from 'formik';
 import { FTextInput, ImageInput } from '../../../components';
 import { useCreateProject, useRouteQuery } from '../../../hooks';
 import { FormCreateProjectMetadata, newDeploymentSchema, projectMetadataSchema } from '../../../models';
-import { isEthError } from '../../../utils';
+import { isEthError, parseError } from '../../../utils';
 import { ROUTES } from '../../../utils';
 import styles from './Create.module.css';
 import Instructions from './Instructions';
@@ -43,7 +43,7 @@ const Create: React.FC = () => {
           setSubmitError(t('errors.transactionRejected'));
           return;
         }
-        setSubmitError((e as Error).message);
+        setSubmitError(parseError(e));
       }
     },
     [navigate, createProject, t],

--- a/src/pages/swap/Swap.tsx
+++ b/src/pages/swap/Swap.tsx
@@ -106,7 +106,6 @@ const SellAUSD = () => {
     mergeAsync(swapRate, swapPool, swapTokens, aUSDBalance, aUSDTotalSupply, usdcToSqtLimitation),
     {
       error: (error) => {
-        console.error('Swap Error: ', error);
         return <Typography.Text type="danger">{`Failed to load info: ${parseError(error) || ''}`}</Typography.Text>;
       },
       empty: () => <Typography.Text type="danger">{`There is no data available`}</Typography.Text>,

--- a/src/utils/eip721SignTokenReq.ts
+++ b/src/utils/eip721SignTokenReq.ts
@@ -65,7 +65,7 @@ export async function requestConsumerHostToken(
 
     return { data: sortedResponse?.token };
   } catch (error) {
-    console.error('Failed to request token of consumer host.');
+    parseError(error);
     return { error: 'Failed to request token of consumer host.' };
   }
 }
@@ -112,7 +112,7 @@ export async function requestServiceAgreementToken(
       throw new Error(parseError(sortedError));
     }
   } catch (error) {
-    console.error('Request Service Agreement Token.', error);
+    parseError(error);
     return { error: 'Failed to request token for service agreement.' };
   }
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,6 +1,8 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { parseError } from './parseError';
+
 interface PostProps {
   endpoint: string;
   headers?: any;
@@ -21,7 +23,7 @@ export const POST = async ({ endpoint, headers, requestBody }: PostProps): Promi
       body: JSON.stringify(requestBody),
     });
   } catch (e) {
-    console.log('Fetch error', e);
+    parseError(e);
     error = e;
   }
 

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -4,6 +4,8 @@
 import { OperationVariables, QueryResult } from '@apollo/client';
 import { Spinner } from '@subql/components';
 import { BigNumber, BigNumberish, utils } from 'ethers';
+
+import { parseError } from './parseError';
 export * from './numberFormatters';
 export * from './stringFormatters';
 export * from './dateFormatters';
@@ -132,10 +134,12 @@ export function renderAsync<T>(data: AsyncData<T>, handlers: Handlers<T>): Rende
     try {
       return handlers.data(data.data, data);
     } catch (e) {
+      parseError(e);
       // TODO not sure this is desired behaviour
       return handlers.error(e as Error);
     }
   } else if (data.error) {
+    parseError(data.error);
     return handlers.error(data.error);
   } else if (data.loading) {
     return handlers.loading ? handlers.loading() : defaultLoading();
@@ -159,11 +163,13 @@ export function renderAsyncArray<T extends any[]>(data: AsyncData<T>, handlers: 
       }
       return handlers.data(data.data, data);
     } catch (e) {
+      parseError(e);
       // TODO not sure this is desired behaviour
       return handlers.error(e as Error);
     }
   }
   if (data.error) {
+    parseError(data.error);
     return handlers.error(data.error);
   } else if (data.loading) {
     return handlers.loading ? handlers.loading() : defaultLoading();

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -47,11 +47,13 @@ export const errors = [
   },
 ];
 
-const generalErrorMsg = 'Unfortunately, something went wrong.';
+export const logError = (msg: string) => {
+  return console.error(`%c [Error] ${msg}`, 'color:lightgreen;font-size:22px');
+};
 
 export function parseError(error: any, errorsMapping = errors): string | undefined {
   if (!error) return;
-  console.log('error', error);
+  logError(error);
   const rawErrorMsg = error?.data?.message ?? error?.message ?? error?.error ?? error ?? '';
 
   const mappingError = () => errorsMapping.find((e) => rawErrorMsg.match(e.error))?.message;
@@ -73,5 +75,14 @@ export function parseError(error: any, errorsMapping = errors): string | undefin
 
     return;
   };
-  return mappingError() ?? mapContractError() ?? callRevert() ?? generalErrorMsg;
+
+  const generalErrorMsg = () => {
+    try {
+      captureException(error);
+    } finally {
+      return 'Unfortunately, something went wrong.';
+    }
+  };
+
+  return mappingError() ?? mapContractError() ?? callRevert() ?? generalErrorMsg();
 }


### PR DESCRIPTION
## Description

Enhance `parseError` and add more side effcets:

- Use `console.error` replace  `console.log` so that will print error stack on dev tools.
- `Gerneral error` will send error information to Sentry(same error will be ignored in one minute).

After merged, error handling:

- **Expect error**:  Handled by code and use `parseError` to get the error information.
- **Unexpected error**: Will send error message to Sentry. 

For user that want to report:

- Highlight the error in dev tools.

Ticket: [#SQN-1530](https://onfinality.atlassian.net/browse/SQN-1530)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## UI Changes

<img width="1281" alt="微信截图_20230620145815" src="https://github.com/subquery/network-explorer/assets/10172415/2e51d75b-d0cd-4132-a565-5d4c541ad898">

