### PR TITLE
feat(SQN-1910): show next era on stake charts

### DIFF
--- a/src/components/LineCharts/index.tsx
+++ b/src/components/LineCharts/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useEra } from '@hooks';
 import { usePropsValue } from '@hooks/usePropsValue';
 import { Spinner, Typography } from '@subql/components';
@@ -103,7 +103,7 @@ const LineCharts: FC<IProps> = ({
         },
       };
     });
-  }, [chartData]);
+  }, [chartData, xAxisScalesInner]);
 
   return (
     <div className={styles.lineCharts}>

--- a/src/pages/dashboard/components/RewardsLineChart/RewardsLineChart.tsx
+++ b/src/pages/dashboard/components/RewardsLineChart/RewardsLineChart.tsx
@@ -15,10 +15,11 @@ import { formatNumber } from '@utils/numberFormatters';
 import { Skeleton } from 'antd';
 import dayjs from 'dayjs';
 
-export const getSplitDataByEra = (currentEra: Era) => {
+export const getSplitDataByEra = (currentEra: Era, includeNextEra = false) => {
   const period = currentEra.period;
   const splitData = 86400;
 
+  const plusedEra = period > splitData ? 1 : Math.floor(splitData / period);
   // TODO:
   //   There have some problems in here
   //   1. secondFromLastTimes / period is just a fuzzy result. also we can get the exactly result by Graphql.
@@ -26,10 +27,11 @@ export const getSplitDataByEra = (currentEra: Era) => {
   //   3. based on 1. and 2. also need to do a lots of things for compatite dev env(1 era < 1 day).
   const getIncludesEras = (lastTimes: dayjs.Dayjs) => {
     const today = dayjs();
-    const secondFromLastTimes = (+today - +lastTimes) / 1000;
+    const secondsFromLastTimes = (+today - +lastTimes) / 1000;
 
-    const eras = Math.ceil(secondFromLastTimes / period);
-    const currentEraIndex = currentEra.index || 0;
+    const eras = Math.ceil(secondsFromLastTimes / period) + (includeNextEra ? plusedEra : 0);
+
+    const currentEraIndex = includeNextEra ? currentEra.index + plusedEra : currentEra.index;
     const includesEras = new Array(eras)
       .fill(0)
       .map((_, index) => currentEraIndex - index)
@@ -80,19 +82,19 @@ export const getSplitDataByEra = (currentEra: Era) => {
 
     // default eras will greater than one day
     if (period > splitData) {
-      const filledPaddingLength = Math.ceil(Math.ceil((paddingLength * splitData) / period));
-      if (filledPaddingLength > renderAmounts.length) {
-        new Array(filledPaddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
+      // const filledPaddingLength = Math.ceil(Math.ceil((paddingLength * splitData) / period));
+      if (paddingLength > renderAmounts.length) {
+        new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
       }
     }
 
     // but in dev env will less than one day.
     if (period < splitData) {
       const eraCountOneDay = splitData / period;
-      const filledPaddingLength = eraCountOneDay * paddingLength;
+      // const filledPaddingLength = eraCountOneDay * paddingLength;
 
-      if (filledPaddingLength > renderAmounts.length) {
-        new Array(filledPaddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
+      if (paddingLength > renderAmounts.length) {
+        new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
       }
 
       renderAmounts = renderAmounts.reduce(
@@ -131,13 +133,19 @@ export const RewardsLineChart = (props: { account?: string; title?: string; data
   });
 
   const rewardsLineXScales = useMemo(() => {
-    const getDefaultScales = xAxisScalesFunc(currentEra.data?.period);
+    const getXScales = (period: number, filterVal: FilterType) => {
+      const getDefaultScales = xAxisScalesFunc(period);
 
-    const result = getDefaultScales[filter.date]();
-    const slicedResult = result.slice(0, result.length - 1);
+      const result = getDefaultScales[filterVal.date]();
+      return result.slice(0, result.length - 1);
+    };
+    const slicedResult = getXScales(currentEra.data?.period || 0, filter);
     return {
-      renderData: slicedResult.map((i) => i.format('MMM D')),
-      rawData: slicedResult,
+      val: {
+        renderData: slicedResult.map((i) => i.format('MMM D')),
+        rawData: slicedResult,
+      },
+      getXScales,
     };
   }, [filter.date, currentEra]);
 
@@ -164,16 +172,17 @@ export const RewardsLineChart = (props: { account?: string; title?: string; data
       fetchPolicy: 'no-cache',
     });
 
-    const maxPaddingLength = { lm: 31, l3m: 90, ly: 365 }[filterVal.date];
-
+    const maxPaddingLength = rewardsLineXScales.getXScales(currentEra.data.period, filterVal).length;
+    // rewards don't want to show lastest era data
+    const removedLastEras = includesErasHex.slice(1, includesErasHex.length);
     const curry = <T extends Parameters<typeof fillData>['0']>(data: T) =>
-      fillData(data, includesErasHex, maxPaddingLength);
+      fillData(data, removedLastEras, maxPaddingLength);
     const indexerRewards = curry(res?.data?.indexerEraReward?.groupedAggregates || []);
     const delegationRewards = curry(res?.data?.delegationEraReward?.groupedAggregates || []);
     setRawRewardsData({
       indexer: indexerRewards,
       delegation: delegationRewards,
-      total: fillData(res?.data?.eraRewards?.groupedAggregates || [], includesErasHex, maxPaddingLength),
+      total: fillData(res?.data?.eraRewards?.groupedAggregates || [], removedLastEras, maxPaddingLength),
     });
 
     setRenderRewards([indexerRewards, delegationRewards]);
@@ -194,7 +203,7 @@ export const RewardsLineChart = (props: { account?: string; title?: string; data
             setFilter(val);
             fetchRewardsByEra(val);
           }}
-          xAxisScales={rewardsLineXScales}
+          xAxisScales={rewardsLineXScales.val}
           title={title}
           dataDimensionsName={dataDimensionsName}
           chartData={renderRewards}

--- a/src/pages/dashboard/components/RewardsLineChart/RewardsLineChart.tsx
+++ b/src/pages/dashboard/components/RewardsLineChart/RewardsLineChart.tsx
@@ -93,10 +93,6 @@ export const getSplitDataByEra = (currentEra: Era, includeNextEra = false) => {
       const eraCountOneDay = splitData / period;
       // const filledPaddingLength = eraCountOneDay * paddingLength;
 
-      if (paddingLength > renderAmounts.length) {
-        new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
-      }
-
       renderAmounts = renderAmounts.reduce(
         (acc: { result: number[]; curResult: number }, cur, index) => {
           if (options?.fillDevDataByGetMax) {
@@ -113,6 +109,10 @@ export const getSplitDataByEra = (currentEra: Era, includeNextEra = false) => {
         },
         { result: [], curResult: 0 },
       ).result;
+
+      if (paddingLength > renderAmounts.length) {
+        new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
+      }
     }
 
     return renderAmounts;

--- a/src/pages/dashboard/components/RewardsLineChart/RewardsLineChart.tsx
+++ b/src/pages/dashboard/components/RewardsLineChart/RewardsLineChart.tsx
@@ -80,19 +80,9 @@ export const getSplitDataByEra = (currentEra: Era, includeNextEra = false) => {
     // Graphql sort is incorrect, because it is a string.
     let renderAmounts = amounts.sort((a, b) => parseInt(a.key, 16) - parseInt(b.key, 16)).map((i) => i.amount);
 
-    // default eras will greater than one day
-    if (period > splitData) {
-      // const filledPaddingLength = Math.ceil(Math.ceil((paddingLength * splitData) / period));
-      if (paddingLength > renderAmounts.length) {
-        new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
-      }
-    }
-
     // but in dev env will less than one day.
     if (period < splitData) {
       const eraCountOneDay = splitData / period;
-      // const filledPaddingLength = eraCountOneDay * paddingLength;
-
       renderAmounts = renderAmounts.reduce(
         (acc: { result: number[]; curResult: number }, cur, index) => {
           if (options?.fillDevDataByGetMax) {
@@ -109,10 +99,10 @@ export const getSplitDataByEra = (currentEra: Era, includeNextEra = false) => {
         },
         { result: [], curResult: 0 },
       ).result;
+    }
 
-      if (paddingLength > renderAmounts.length) {
-        new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
-      }
+    if (paddingLength > renderAmounts.length) {
+      new Array(paddingLength - renderAmounts.length).fill(0).forEach((_) => renderAmounts.unshift(0));
     }
 
     return renderAmounts;

--- a/src/pages/dashboard/components/StakeAndDelegationLineChart/StakeAndDelegationLineChart.tsx
+++ b/src/pages/dashboard/components/StakeAndDelegationLineChart/StakeAndDelegationLineChart.tsx
@@ -135,7 +135,7 @@ export const StakeAndDelegationLineChart = (props: {
     const paddedData = padLostEraData(
       DeepCloneAndChangeReadonlyToMutable(res?.data?.indexerStakes?.groupedAggregates) || [],
     );
-    // const maxPaddingLength = { lm: 31, l3m: 90, ly: 365 }[filterVal.date];
+
     const curry = <T extends Parameters<typeof fillData>['0']>(data: T) =>
       fillData(
         data,

--- a/src/pages/dashboard/components/StakeAndDelegationLineChart/StakeAndDelegationLineChart.tsx
+++ b/src/pages/dashboard/components/StakeAndDelegationLineChart/StakeAndDelegationLineChart.tsx
@@ -1,8 +1,8 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
-import LineCharts, { FilterType } from '@components/LineCharts';
+import { useEffect, useMemo, useState } from 'react';
+import LineCharts, { FilterType, xAxisScalesFunc } from '@components/LineCharts';
 import { useEra } from '@hooks';
 import { captureMessage } from '@sentry/react';
 import { Typography } from '@subql/components';
@@ -40,10 +40,27 @@ export const StakeAndDelegationLineChart = (props: {
     total: [],
   });
 
-  const fetchStakeAndDelegationByEra = async (filterVal: FilterType | undefined = filter) => {
+  const stakeLineXScales = useMemo(() => {
+    const getLatestXScales = (period: number, filterVal: FilterType) => {
+      const defaultXScalesFunc = xAxisScalesFunc(period)[filterVal.date];
+      const futureEraEndTime = (period || 0) < 86400 ? dayjs().add(1, 'day') : dayjs().add(period || 0, 'seconds');
+      return [...defaultXScalesFunc(), futureEraEndTime];
+    };
+
+    const xScalesVal = getLatestXScales(currentEra.data?.period || 0, filter);
+    return {
+      val: {
+        renderData: xScalesVal.map((i) => i.format('MMM D')),
+        rawData: xScalesVal,
+      },
+      getLatestXScales,
+    };
+  }, [currentEra, filter.date]);
+
+  const fetchStakeAndDelegationByEra = async (filterVal: FilterType = filter) => {
     if (!currentEra.data) return;
     if (!filterVal) return;
-    const { getIncludesEras, fillData } = getSplitDataByEra(currentEra.data);
+    const { getIncludesEras, fillData } = getSplitDataByEra(currentEra.data, true);
 
     const { includesErasHex, allErasHex } = {
       lm: () => getIncludesEras(dayjs().subtract(31, 'day')),
@@ -101,7 +118,7 @@ export const StakeAndDelegationLineChart = (props: {
         .map((item) => {
           if (!item.fixme) {
             if (!item.sum) {
-              captureMessage('fetched stake and delegation data, please confirm.');
+              captureMessage('fetched stake and delegation data error, please confirm.');
               return item;
             }
             currentSums = { ...item.sum };
@@ -118,10 +135,16 @@ export const StakeAndDelegationLineChart = (props: {
     const paddedData = padLostEraData(
       DeepCloneAndChangeReadonlyToMutable(res?.data?.indexerStakes?.groupedAggregates) || [],
     );
-
-    const maxPaddingLength = { lm: 31, l3m: 90, ly: 365 }[filterVal.date];
+    // const maxPaddingLength = { lm: 31, l3m: 90, ly: 365 }[filterVal.date];
     const curry = <T extends Parameters<typeof fillData>['0']>(data: T) =>
-      fillData(data, includesErasHex, maxPaddingLength, { fillDevDataByGetMax: true });
+      fillData(
+        data,
+        includesErasHex,
+        stakeLineXScales.getLatestXScales(currentEra.data?.period || 0, filterVal).length,
+        {
+          fillDevDataByGetMax: true,
+        },
+      );
 
     const indexerStakes = curry(paddedData.map((i) => ({ ...i, sum: { amount: i?.sum?.indexerStake || '0' } })));
     const delegationStakes = curry(paddedData.map((i) => ({ ...i, sum: { amount: i?.sum?.delegatorStake || '0' } })));
@@ -149,6 +172,7 @@ export const StakeAndDelegationLineChart = (props: {
             setFilter(val);
             fetchStakeAndDelegationByEra(val);
           }}
+          xAxisScales={stakeLineXScales.val}
           title={title}
           dataDimensionsName={dataDimensionsName}
           chartData={renderStakeAndDelegation}

--- a/src/pages/indexer/IndexerProfile/IndexerProfile.tsx
+++ b/src/pages/indexer/IndexerProfile/IndexerProfile.tsx
@@ -156,7 +156,7 @@ const ActiveCard = (props: { account: string }) => {
                   src={project.projectMeta.image || '/static/default.project.png'}
                   className={styles.image}
                   onClick={() => {
-                    navigate(`/explorer/project/${project.id}`);
+                    navigate(`/explorer/project/${project.projectId}`);
                   }}
                 />
               ))}


### PR DESCRIPTION
## Description

- Show next era stake data.

Ticket: [SQN-1910](https://onfinality.atlassian.net/browse/SQN-1910)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## UI Changes

![SCR-20230912-nmzj](https://github.com/subquery/network-app/assets/10172415/81125520-653e-4721-a289-44f39516f157)
