### PR TITLE
fix: social credibility style issue

### DIFF
--- a/src/pages/indexer/IndexerProfile/IndexerProfile.tsx
+++ b/src/pages/indexer/IndexerProfile/IndexerProfile.tsx
@@ -118,7 +118,9 @@ const AccountBaseInfo = (props: { account: string }) => {
       {makeChunk({
         title: 'SSL',
         value: (
-          <Tag color="green">{accountInfos?.infos?.sslEnabled ? t('general.enabled') : t('general.disabled')}</Tag>
+          <Tag color={accountInfos?.infos?.sslEnabled ? 'green' : 'default'}>
+            {accountInfos?.infos?.sslEnabled ? t('general.enabled') : t('general.disabled')}
+          </Tag>
         ),
       })}
 
@@ -126,7 +128,7 @@ const AccountBaseInfo = (props: { account: string }) => {
         title: 'Social Credibility',
         value: (
           <div>
-            <Tag color="green">
+            <Tag color={accountInfos?.infos?.socialCredibility ? 'green' : 'default'}>
               {accountInfos?.infos?.socialCredibility ? t('general.enabled') : t('general.disabled')}
             </Tag>
           </div>


### PR DESCRIPTION
## Description

- If the status of social credibility is disabled, the color of tag should be gray not green(SSL status also apply this rule). 

## Type of change

- [x] Improvements (ie: code cleaning or remove unused codes or performance issue)

## UI Changes

![image](https://github.com/subquery/network-app/assets/10172415/35ca1ac3-382a-47d6-acaf-cfb77b6ae9fd)

