### PR TITLE
fix: search loading & infinity render on project detail

### DIFF
--- a/src/pages/explorer/Home/Home.tsx
+++ b/src/pages/explorer/Home/Home.tsx
@@ -88,6 +88,11 @@ const Home: React.FC = () => {
   const loadMore = async (options?: { refresh?: boolean }) => {
     try {
       setLoading(true);
+      if (searchKeywords.length) {
+        setInSearchMode(true);
+      } else {
+        setInSearchMode(false);
+      }
       const api = searchKeywords.length ? getProjectBySearch : getProjects;
 
       const params = searchKeywords.length
@@ -118,12 +123,6 @@ const Home: React.FC = () => {
         setProjects(mergered);
         updatedLength = mergered.length;
         setTotal(res.data?.projects?.totalCount);
-      }
-
-      if (searchKeywords.length) {
-        setInSearchMode(true);
-      } else {
-        setInSearchMode(false);
       }
 
       return {
@@ -194,6 +193,12 @@ const Home: React.FC = () => {
             return <Skeleton paragraph={{ rows: 7 }} active key={i} style={{ width: 236, height: 400 }}></Skeleton>;
           })}
       </div>
+
+      {inSearchMode && !projects.length && (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Typography>No projects match your search</Typography>
+        </div>
+      )}
 
       {(error || topError) && <span>{`We have an error: ${error?.message || topError?.message}`}</span>}
     </div>

--- a/src/pages/explorer/Project/Project.tsx
+++ b/src/pages/explorer/Project/Project.tsx
@@ -92,7 +92,7 @@ const ProjectInner: React.FC = () => {
     if (deployments && !deploymentVersions) {
       getVersions();
     }
-  }, [deploymentVersions, deployments, getVersionMetadata]);
+  }, [deployments, getVersionMetadata]);
 
   const page = renderAsync(asyncProject, {
     loading: () => <Spinner />,


### PR DESCRIPTION
## Description

- Add empty tips on projects list when searched nothing.
- Adjust search loading judgement.
- Remove `deploymentVersions` dependency on project detail that would affect infinity render.


## Type of change

- [x] New feature (non-breaking change which adds functionality)


## UI Changes

![image](https://github.com/subquery/network-app/assets/10172415/0f85ae98-20cd-41dd-86c6-c118c693bdcf)
