### PR TITLE
fix: rewards page, query rewards, loading, dashboard graph, update balance after did delegate

### DIFF
--- a/src/components/AccountActions/AccountActions.tsx
+++ b/src/components/AccountActions/AccountActions.tsx
@@ -79,7 +79,9 @@ export const AccountActions: React.FC<{ account: string }> = ({ account }) => {
                       Wallet balance on Base
                     </Typography>
                     {balance.result.loading ? (
-                      <Spinner size={10}></Spinner>
+                      <div style={{ lineHeight: '24px' }}>
+                        <Spinner size={12}></Spinner>
+                      </div>
                     ) : (
                       <Typography weight={600}>
                         {formatEther(balance.result.data, 4)} {TOKEN}
@@ -105,7 +107,9 @@ export const AccountActions: React.FC<{ account: string }> = ({ account }) => {
                       </Tooltip>
                     </Typography>
                     {ethSqtBalance.result.loading ? (
-                      <Spinner size={10}></Spinner>
+                      <div style={{ lineHeight: '24px' }}>
+                        <Spinner size={12}></Spinner>
+                      </div>
                     ) : (
                       <Typography weight={600}>
                         {formatEther(ethSqtBalance.result.data, 4)} {TOKEN}
@@ -156,7 +160,9 @@ export const AccountActions: React.FC<{ account: string }> = ({ account }) => {
                   <div style={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography>Billing Balance:</Typography>
                     {consumerHostBalance.result.loading ? (
-                      <Spinner></Spinner>
+                      <div style={{ lineHeight: '24px' }}>
+                        <Spinner size={12}></Spinner>
+                      </div>
                     ) : (
                       <Typography>
                         {formatEther(consumerHostBalance.result.data?.balance, 4)} {TOKEN}

--- a/src/components/ProjectOverview/ProjectOverview.tsx
+++ b/src/components/ProjectOverview/ProjectOverview.tsx
@@ -122,12 +122,12 @@ const ProjectOverview: React.FC<Props> = ({ project, metadata, deploymentDescrip
       current: BigNumber.from(
         BignumberJs(currentRewards?.toString() || '0')
           .multipliedBy(queryRewardsRate.data)
-          .toFixed() || '0',
+          .toFixed(0) || '0',
       ),
       previous: BigNumber.from(
         BignumberJs(prevRewards?.toString() || '0')
           .multipliedBy(queryRewardsRate.data)
-          .toFixed() || '0',
+          .toFixed(0) || '0',
       ),
     });
   };

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { matchPath, Outlet, useNavigate, useParams } from 'react-router';
+import { WalletRoute } from '@components';
 import NewCard from '@components/NewCard';
 import RpcError from '@components/RpcError';
 import { useSortedIndexer } from '@hooks';
@@ -77,7 +78,7 @@ const activeKeyLinks: {
   Withdrawals: '/profile/withdrawn',
 };
 
-export const MyAccount: React.FC = () => {
+export const MyAccountInner: React.FC = () => {
   const { address } = useAccount();
   const { id: profileAccount } = useParams();
   const account = useMemo(() => toChecksumAddress(profileAccount || address || ''), [address, profileAccount]);
@@ -237,6 +238,10 @@ export const MyAccount: React.FC = () => {
       <Footer simple></Footer>
     </div>
   );
+};
+
+export const MyAccount = () => {
+  return <WalletRoute componentMode element={<MyAccountInner></MyAccountInner>}></WalletRoute>;
 };
 
 export default MyAccount;

--- a/src/pages/dashboard/components/StakeAndDelegationLineChart/StakeAndDelegationLineChart.tsx
+++ b/src/pages/dashboard/components/StakeAndDelegationLineChart/StakeAndDelegationLineChart.tsx
@@ -195,7 +195,7 @@ export const StakeAndDelegationLineChart = (props: {
         },
       );
 
-    const delegateToMe = curry(paddedData.map((i) => ({ ...i, sum: { amount: i?.sum?.totalStake || '0' } })));
+    const delegateToMe = curry(paddedData.map((i) => ({ ...i, sum: { amount: i?.sum?.delegatorStake || '0' } })));
     const IDelegateToOthers = curry(
       paddedDelegatorToOthersData.map((i) => ({
         ...i,

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -218,7 +218,9 @@ const Dashboard: FC = () => {
     const res = await fetch('https://sqt.subquery.foundation/circulating');
     const data: string = await res.text();
 
-    setCircleAmount(BigNumber(data).toString());
+    if (!BigNumber(data).isNaN()) {
+      setCircleAmount(BigNumber(data).toString());
+    }
   };
 
   useEffect(() => {

--- a/src/pages/delegator/DoDelegate/DoDelegate.tsx
+++ b/src/pages/delegator/DoDelegate/DoDelegate.tsx
@@ -67,6 +67,7 @@ export const DoDelegate: React.FC<DoDelegateProps> = ({
   onSuccess,
 }) => {
   const { t } = useTranslation();
+  const { balance } = useSQToken();
   const { currentEra, refetch } = useEra();
   const { account } = useWeb3();
   const { contracts } = useWeb3Store();
@@ -212,6 +213,7 @@ export const DoDelegate: React.FC<DoDelegateProps> = ({
               getDelegationLazy();
               getIndexerLazy();
             });
+            balance.refetch();
             onSuccess?.();
           }}
           onClick={handleClick}


### PR DESCRIPTION
## Description

- Fix rewards page showing blank bug if user didn't login.
- Fix query rewards displaying if the rewards are float.
- Improve loading status on account dropdown.
- Fix dashboard stake graph bug.
- Add refresh balance after user did delegate. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvements (ie: code cleaning or remove unused codes or performance issue)

