### PR TITLE
feat: improve my projects & all operators page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@subql/apollo-links": "1.4.1",
     "@subql/components": "2.0.1-2",
     "@subql/contract-sdk": "1.0.3",
-    "@subql/network-clients": "1.1.1-3",
+    "@subql/network-clients": "1.1.1-4",
     "@subql/network-config": "1.1.1",
     "@subql/network-query": "1.1.2-12",
     "@subql/react-hooks": "1.1.2-13",

--- a/src/components/CreateFlexPlan/index.tsx
+++ b/src/components/CreateFlexPlan/index.tsx
@@ -369,15 +369,17 @@ const CreateFlexPlan: FC<IProps> = ({ deploymentId, project, prevHostingPlan, pr
       }
 
       // TODO: make a enum
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       setDisplayTransactions(newDisplayTransactions);
 
       setTransactionNumbers(
-        newDisplayTransactions.reduce((acc, cur, index) => {
-          acc[cur] = index + 1;
-          return acc;
-        }, {} as { [key in string]: number }),
+        newDisplayTransactions.reduce(
+          (acc, cur, index) => {
+            acc[cur] = index + 1;
+            return acc;
+          },
+          {} as { [key in string]: number },
+        ),
       );
       setCurrentStep(2);
     }

--- a/src/components/DeploymentInfo/DeploymentInfo.module.css
+++ b/src/components/DeploymentInfo/DeploymentInfo.module.css
@@ -13,6 +13,7 @@
   height: 68px;
   border-radius: 8px;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .projectTextInfo {

--- a/src/components/IndexerDetails/IndexerName.tsx
+++ b/src/components/IndexerDetails/IndexerName.tsx
@@ -5,10 +5,13 @@ import { FC, useEffect, useMemo, useState } from 'react';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { Typography } from '@subql/components';
+import { IndexerMetadata } from '@subql/network-clients';
 import { idleCallback } from '@utils/idleCallback';
 import { limitContract } from '@utils/limitation';
 import { message } from 'antd';
 import { toSvg } from 'jdenticon';
+
+import { IndexerDetails } from 'src/models';
 
 import { useIndexerMetadata } from '../../hooks';
 import { useWeb3Name } from '../../hooks/useSpaceId';
@@ -136,8 +139,11 @@ export const ConnectedIndexer: React.FC<{
   onAddressClick?: (id: string) => void;
   onClick?: (address: string) => void;
   clickToProfile?: boolean;
-}> = ({ id, account, size = 'normal', clickToProfile, onAddressClick, onClick }) => {
-  const { indexerMetadata, loading } = useIndexerMetadata(id);
+  metadata?: IndexerMetadata | IndexerDetails;
+}> = ({ id, account, size = 'normal', clickToProfile, onAddressClick, onClick, metadata }) => {
+  const { indexerMetadata, loading } = useIndexerMetadata(id, {
+    immediate: metadata ? false : true,
+  });
   const navigate = useNavigate();
 
   return (

--- a/src/hooks/useIndexerMetadata.tsx
+++ b/src/hooks/useIndexerMetadata.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useGetIndexerLazyQuery } from '@subql/react-hooks';
 import { limitQueue } from '@utils/limitation';
 import localforage from 'localforage';
@@ -36,6 +36,7 @@ export function useIndexerMetadata(
   const [metadata, setMetadata] = useState<IndexerDetails>();
   const [loading, setLoading] = useState(false);
   const [getIndexerQuery] = useGetIndexerLazyQuery();
+  const mounted = useRef(false);
   const fetchCid = async () => {
     const res = await getIndexerQuery({
       variables: {
@@ -94,6 +95,11 @@ export function useIndexerMetadata(
   }, [optionWithDefault.immediate]);
 
   useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      return;
+    }
+    if (!address) return;
     refresh();
   }, [address]);
 

--- a/src/hooks/useSortedIndexerDeployments.tsx
+++ b/src/hooks/useSortedIndexerDeployments.tsx
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { gql, useQuery } from '@apollo/client';
 import { indexingProgress } from '@subql/network-clients';
 import { IndexerDeploymentNodeFieldsFragment as DeploymentIndexer, ServiceStatus } from '@subql/network-query';
 import {
@@ -13,6 +14,7 @@ import { useProjectMetadata } from '../containers';
 import { ProjectMetadata } from '../models';
 import { AsyncData, getDeploymentMetadata } from '../utils';
 import { useAsyncMemo } from './useAsyncMemo';
+import { useEra } from './useEra';
 import { useIndexerMetadata } from './useIndexerMetadata';
 
 export interface UseSortedIndexerDeploymentsReturn extends Pick<DeploymentIndexer, 'deployment'> {
@@ -27,12 +29,14 @@ export interface UseSortedIndexerDeploymentsReturn extends Pick<DeploymentIndexe
   lastHeight: number;
   indexingProgress: number;
   allocatedAmount?: string;
-  allocatedTotalRewards?: string;
+  lastEraAllocatedRewards?: string;
+  lastEraBurnt?: string;
 }
 
 // TODO: apply with query hook
 export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<UseSortedIndexerDeploymentsReturn>> {
   const { getMetadataFromCid } = useProjectMetadata();
+  const { currentEra } = useEra();
   const indexerDeployments = useGetDeploymentIndexersByIndexerQuery({
     variables: { indexerAddress: indexer },
     fetchPolicy: 'network-only',
@@ -45,12 +49,37 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
     fetchPolicy: 'network-only',
   });
 
-  const allocatedRewards = useGetAllocationRewardsByDeploymentIdAndIndexerIdQuery({
-    variables: {
-      indexerId: indexer || '',
+  const lastEraAllocatedRewardsAndBurned = useQuery<{
+    indexerAllocationRewards: {
+      groupedAggregates: Array<{
+        keys: Array<string>;
+        sum: {
+          reward: string;
+          burnt: string;
+        };
+      }>;
+    };
+  }>(
+    gql`
+      query GetAllocationRewardsByDeploymentIdAndIndexerId($indexerId: String!, $eraIdx: Int!) {
+        indexerAllocationRewards(filter: { indexerId: { equalTo: $indexerId }, eraIdx: { equalTo: $eraIdx } }) {
+          groupedAggregates(groupBy: DEPLOYMENT_ID) {
+            sum {
+              reward
+              burnt
+            }
+            keys
+          }
+        }
+      }
+    `,
+    {
+      variables: {
+        indexerId: indexer || '',
+        eraIdx: (currentEra.data?.index || 0) - 1,
+      },
     },
-    fetchPolicy: 'network-only',
-  });
+  );
 
   const { indexerMetadata } = useIndexerMetadata(indexer);
   const proxyEndpoint = indexerMetadata?.url;
@@ -106,11 +135,13 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
         const allocatedAmount = allocatedProjects.data?.indexerAllocationSummaries?.nodes
           .find((i) => i?.deploymentId === deploymentId)
           ?.totalAmount.toString();
-        const allocatedTotalRewards = allocatedRewards.data?.indexerAllocationRewards?.groupedAggregates
-          ?.find((i) => {
+        const allocationInfo = lastEraAllocatedRewardsAndBurned.data?.indexerAllocationRewards?.groupedAggregates?.find(
+          (i) => {
             return i?.keys?.[0] === deploymentId;
-          })
-          ?.sum?.reward.toString();
+          },
+        );
+        const lastEraAllocatedRewards = allocationInfo?.sum?.reward?.toString();
+        const lastEraBurnt = allocationInfo?.sum?.burnt?.toString();
 
         const projectId = indexerDeployment?.deployment?.project?.id;
 
@@ -127,20 +158,21 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
             ...metadata,
           },
           allocatedAmount,
-          allocatedTotalRewards,
+          lastEraAllocatedRewards,
+          lastEraBurnt,
           id: indexerDeployment?.id,
           deployment: indexerDeployment?.deployment || null,
         };
       }),
     );
-  }, [indexerDeployments.loading, proxyEndpoint, allocatedProjects.data, allocatedRewards.data]);
+  }, [indexerDeployments.loading, proxyEndpoint, allocatedProjects.data, lastEraAllocatedRewardsAndBurned.data]);
 
   return {
     ...sortedIndexerDeployments,
     refetch: async () => {
       await indexerDeployments.refetch();
       await allocatedProjects.refetch();
-      await allocatedRewards.refetch();
+      await lastEraAllocatedRewardsAndBurned.refetch();
     },
   };
 }

--- a/src/hooks/useSortedIndexerDeployments.tsx
+++ b/src/hooks/useSortedIndexerDeployments.tsx
@@ -44,6 +44,7 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
     },
     fetchPolicy: 'network-only',
   });
+
   const allocatedRewards = useGetAllocationRewardsByDeploymentIdAndIndexerIdQuery({
     variables: {
       indexerId: indexer || '',
@@ -62,12 +63,7 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
     );
 
     // merge have allocation but not indexing project
-    const mergedDeployments = [
-      ...filteredDeployments,
-      ...(allocatedProjects.data?.indexerAllocationSummaries?.nodes.filter(
-        (i) => !filteredDeployments.find((j) => j?.deploymentId === i?.deploymentId),
-      ) || []),
-    ];
+    const mergedDeployments = filteredDeployments;
 
     return await Promise.all(
       mergedDeployments.map(async (indexerDeployment) => {
@@ -83,10 +79,7 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
               categories: [],
             };
 
-        const deploymentId =
-          indexerDeployment?.__typename === 'IndexerAllocationSummary'
-            ? indexerDeployment.deploymentId
-            : indexerDeployment?.deployment?.id;
+        const deploymentId = indexerDeployment?.deployment?.id;
         // TODO: get `offline` status from external api call
         const isOffline = false;
         let indexingErr = '';
@@ -119,13 +112,10 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
           })
           ?.sum?.reward.toString();
 
-        const projectId =
-          indexerDeployment?.__typename === 'IndexerDeployment'
-            ? indexerDeployment.deployment?.project?.id
-            : indexerDeployment?.projectId;
+        const projectId = indexerDeployment?.deployment?.project?.id;
 
         return {
-          status: indexerDeployment?.__typename === 'IndexerAllocationSummary' ? undefined : indexerDeployment?.status,
+          status: indexerDeployment?.status,
           indexingErr,
           indexingProgress: sortedIndexingProcess,
           lastHeight,
@@ -138,11 +128,8 @@ export function useSortedIndexerDeployments(indexer: string): AsyncData<Array<Us
           },
           allocatedAmount,
           allocatedTotalRewards,
-          id:
-            indexerDeployment?.__typename === 'IndexerAllocationSummary'
-              ? indexerDeployment.deploymentId
-              : indexerDeployment?.id,
-          deployment: indexerDeployment?.__typename === 'IndexerDeployment' ? indexerDeployment.deployment : null,
+          id: indexerDeployment?.id,
+          deployment: indexerDeployment?.deployment || null,
         };
       }),
     );

--- a/src/pages/delegator/DoDelegate/DoDelegate.tsx
+++ b/src/pages/delegator/DoDelegate/DoDelegate.tsx
@@ -76,8 +76,10 @@ export const DoDelegate: React.FC<DoDelegateProps> = ({
   const { account } = useWeb3();
   const { contracts } = useWeb3Store();
   const rewardClaimStatus = useRewardCollectStatus(indexerAddress, true);
-  const indexerCapacityFromContract = useGetCapacityFromContract(indexerAddress);
-  const { indexerMetadata: indexerMetadataIpfs } = useIndexerMetadata(indexerAddress);
+  const indexerCapacityFromContract = useGetCapacityFromContract(indexerAddress, indexer);
+  const { indexerMetadata: indexerMetadataIpfs, refresh } = useIndexerMetadata(indexerAddress, {
+    immediate: false,
+  });
   const { fetchWeb3NameFromCache } = useWeb3Name();
   const { refreshAndMakeInactiveOperatorNotification, refreshAndMakeInOrDecreaseCommissionNotification } =
     useMakeNotification();
@@ -152,6 +154,7 @@ export const DoDelegate: React.FC<DoDelegateProps> = ({
       if (!isLogin) return;
       setShouldFetchStatus(false);
       setFetchCheckStatusLoading(true);
+      await refresh();
       const approval = await stakingAllowance.refetch();
       setRequireTokenApproval(approval?.data?.isZero() || false);
       if (!delegation) {

--- a/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.module.css
+++ b/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.module.css
@@ -23,7 +23,8 @@
 
 .stakeInfo {
   display: flex;
-  gap: 53px;
+  gap: 12px;
+  flex-direction: column;
 }
 
 @media (max-width: 768px) {

--- a/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
+++ b/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
@@ -526,7 +526,14 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                         {
                           name: isOverAllocate ? 'Over Allocated' : 'Unallocated Stake',
                           color: 'var(--sq-warning)',
-                          currentBalance: formatNumber(BigNumberJs(runnerAllocationData?.left || 0).toString()),
+                          currentBalance: formatNumber(
+                            BigNumberJs(runnerAllocationData?.left || 0)
+                              .abs()
+                              .toString(),
+                          ),
+                          rawValue: BigNumberJs(runnerAllocationData?.left || 0)
+                            .abs()
+                            .toFixed(18),
                           isOverAllocate: isOverAllocate,
                         },
                       ].map((item) => {
@@ -557,7 +564,9 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                             </Typography>
                             <div className="col-flex" style={{ alignItems: 'flex-end' }}>
                               <Typography variant="medium">
-                                {item.currentBalance} {TOKEN}
+                                <Tooltip title={item.rawValue ? item.rawValue : ''}>
+                                  {item.currentBalance} {TOKEN}
+                                </Tooltip>
                                 {item.isOverAllocate && (
                                   <Tooltip title="Your current allocation amount exceeds your available stake. Please adjust to align with your available balance. ">
                                     <WarningOutlined style={{ marginLeft: 4, color: 'var(--sq-error)' }} />

--- a/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
+++ b/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
@@ -178,7 +178,7 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
           className="flex-center"
           style={{ textTransform: 'uppercase' }}
         >
-          Estimated APY
+          Previous Estimated APY
           <APYTooltip
             currentEra={currentEra?.data?.index}
             calculationDescription={
@@ -187,13 +187,14 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
           />
         </Typography>
       ),
-
+      width: 230,
       dataIndex: 'deploymentApy',
       render: (deploymentApy) => {
         return <Typography>{deploymentApy.toFixed(2)} %</Typography>;
       },
     },
     {
+      width: 230,
       title: <TableTitle title="Allocated amount" />,
       dataIndex: 'allocatedAmount',
       render: (allocatedAmount: string) => {
@@ -203,21 +204,54 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
           </Typography>
         );
       },
+      sorter: (a, b) => {
+        return BigNumberJs(a.allocatedAmount || '0').comparedTo(b.allocatedAmount || '0');
+      },
     },
     {
-      title: <TableTitle title="Total rewards" />,
-      dataIndex: 'allocatedTotalRewards',
-      render: (allocatedTotalRewards, deployment) => {
+      width: 230,
+      title: <TableTitle title="LAST ERA ALLOCATION REWARDS" />,
+      dataIndex: 'lastEraAllocatedRewards',
+      render: (lastEraAllocatedRewards) => {
         return (
           <Typography>
-            {formatNumber(formatSQT(allocatedTotalRewards || '0'))} {TOKEN}
+            {formatNumber(formatSQT(lastEraAllocatedRewards || '0'))} {TOKEN}
           </Typography>
         );
+      },
+      sorter: (a, b) => {
+        return BigNumberJs(a.lastEraAllocatedRewards || '0').comparedTo(b.lastEraAllocatedRewards || '0');
+      },
+    },
+    {
+      width: 230,
+      title: <TableTitle title="LAST ERA BURNED REWARDS" />,
+      dataIndex: 'lastEraBurnt',
+      render: (lastEraBurnt, deployment) => {
+        const haveBurnt = !BigNumberJs(lastEraBurnt || '0').isZero();
+        const percentageOfBurnt = BigNumberJs(lastEraBurnt || '0')
+          .div(BigNumberJs(deployment.lastEraAllocatedRewards || '0').plus(lastEraBurnt || '0'))
+          .multipliedBy(100)
+          .toFixed(2);
+        return (
+          <Typography type={haveBurnt ? 'danger' : 'default'} className="col-flex">
+            {formatNumber(formatSQT(lastEraBurnt || '0'))} {TOKEN}
+            {haveBurnt ? (
+              <Typography variant="small" type="secondary">
+                {percentageOfBurnt}% of rewards
+              </Typography>
+            ) : null}
+          </Typography>
+        );
+      },
+      sorter: (a, b) => {
+        return BigNumberJs(a.lastEraBurnt || '0').comparedTo(b.lastEraBurnt || '0');
       },
     },
     {
       title: <TableTitle title={t('general.action')} />,
       dataIndex: 'status',
+      fixed: 'right',
       render: (status, deployment) => {
         return (
           <div style={{ display: 'flex', gap: 26 }}>
@@ -627,20 +661,6 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                         );
                       })}
                     </div>
-                    {/* <div className="flex">
-                      <Typography>Total Allocation Rewards</Typography>
-                      <span style={{ flex: 1 }}></span>
-                      <Typography>
-                        {formatNumber(
-                          formatSQT(
-                            allocatedRewards.data?.indexerAllocationRewards?.groupedAggregates
-                              ?.reduce((cur, add) => cur.plus(add.sum?.reward.toString() || '0'), BigNumberJs(0))
-                              .toString() || '0',
-                          ),
-                        )}{' '}
-                        {TOKEN}
-                      </Typography>
-                    </div> */}
                   </SubqlCard>
                 </div>
                 {!indexerDeployments.loading && (!indexerDepolymentsData || indexerDepolymentsData.length === 0) ? (
@@ -651,7 +671,7 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                     dataSource={indexerDeployments.loading ? previousSortedData : sortedData}
                     rowKey={'deploymentId'}
                     pagination={false}
-                    scroll={width <= 768 ? { x: 1600 } : undefined}
+                    scroll={width <= 1800 ? { x: 1800 } : undefined}
                     loading={indexerDeployments.loading}
                   />
                 )}

--- a/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
+++ b/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
@@ -119,7 +119,7 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
 
   const previousSortedData = usePrevious(sortedData);
 
-  const columns: TableProps<UseSortedIndexerDeploymentsReturn>['columns'] = [
+  const columns: TableProps<UseSortedIndexerDeploymentsReturn & { deploymentApy: BigNumberJs }>['columns'] = [
     {
       title: 'Project',
       dataIndex: 'deploymentId',
@@ -191,6 +191,9 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
       dataIndex: 'deploymentApy',
       render: (deploymentApy) => {
         return <Typography>{deploymentApy.toFixed(2)} %</Typography>;
+      },
+      sorter: (a, b) => {
+        return BigNumberJs(a.deploymentApy || '0').comparedTo(b.deploymentApy || '0');
       },
     },
     {

--- a/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
+++ b/src/pages/indexer/MyProjects/OwnDeployments/OwnDeployments.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import InfoCircleOutlined from '@ant-design/icons/InfoCircleOutlined';
 import WarningOutlined from '@ant-design/icons/WarningOutlined';
 import { gql, useLazyQuery } from '@apollo/client';
 import DoAllocate from '@components/DoAllocate/DoAllocate';
@@ -12,12 +11,7 @@ import { BalanceLayout } from '@pages/dashboard';
 import { DoStake } from '@pages/indexer/MyStaking/DoStake';
 import { Spinner, SubqlCard, Typography } from '@subql/components';
 import { TableTitle } from '@subql/components';
-import {
-  formatSQT,
-  mergeAsync,
-  useAsyncMemo,
-  useGetAllocationRewardsByDeploymentIdAndIndexerIdQuery,
-} from '@subql/react-hooks';
+import { formatSQT, mergeAsync, useAsyncMemo } from '@subql/react-hooks';
 import { getDeploymentStatus } from '@utils/getIndexerStatus';
 import { usePrevious, useSize } from 'ahooks';
 import { Table, TableProps, Tooltip } from 'antd';
@@ -35,7 +29,7 @@ import {
   useSortedIndexerDeployments,
   UseSortedIndexerDeploymentsReturn,
 } from '../../../../hooks';
-import { formatNumber, renderAsync, TOKEN, truncateToDecimalPlace } from '../../../../utils';
+import { formatNumber, numToHex, renderAsync, TOKEN, truncateToDecimalPlace } from '../../../../utils';
 import { ROUTES } from '../../../../utils';
 import { formatEther } from '../../../../utils/numberFormatters';
 import styles from './OwnDeployments.module.css';
@@ -58,12 +52,6 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
   const { contracts } = useWeb3Store();
   const { currentEra } = useEra();
 
-  const allocatedRewards = useGetAllocationRewardsByDeploymentIdAndIndexerIdQuery({
-    variables: {
-      indexerId: indexer || '',
-    },
-  });
-
   const [fetchIndexerDeploymentApy, indexerDeploymentApy] = useLazyQuery(gql`
     query GetDeploymentApy($account: String!, $eraIdx: Int!, $deploymentIds: [String!]) {
       eraIndexerDeploymentApies(
@@ -73,6 +61,23 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
           apy
           deploymentId
           indexerId
+        }
+      }
+    }
+  `);
+
+  const [fetchIndexerLastEraRewardsInfo, indexerLastEraRewardsInfo] = useLazyQuery(gql`
+    query GetIndexerLastEraRewardsInfo($id: String!, $indexer: String!, $eraIdx: Int!) {
+      indexerReward(id: $id) {
+        amount
+      }
+
+      indexerAllocationRewards(filter: { indexerId: { equalTo: $indexer }, eraIdx: { equalTo: $eraIdx } }) {
+        aggregates {
+          sum {
+            burnt
+            reward
+          }
         }
       }
     }
@@ -260,6 +265,14 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
           deploymentIds: indexerDeployments.data?.map((item) => item.deploymentId) || [],
         },
       });
+
+      fetchIndexerLastEraRewardsInfo({
+        variables: {
+          id: `${indexer}:${numToHex(currentEra.data?.index - 1)}`,
+          indexer: indexer,
+          eraIdx: currentEra.data?.index - 1,
+        },
+      });
     }
   }, [indexer, currentEra.data?.index, indexerDeployments.data]);
 
@@ -283,19 +296,40 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
               return <>{emptyList ?? <Typography> {t('projects.nonDeployments')} </Typography>}</>;
             }
 
+            // stake
             const totalStake = BigNumberJs(sortedIndexerData?.ownStake.current || 0).plus(
               BigNumberJs(sortedIndexerData?.totalDelegations.current || 0),
             );
-            const unallocatedStakeRatio = BigNumberJs(runnerAllocationData?.left || 0).div(totalStake);
-            const allocatedStakeRatio = BigNumberJs(1).minus(unallocatedStakeRatio);
             const ownStakeRatio = BigNumberJs(sortedIndexerData?.ownStake.current || 0).div(totalStake);
             const renderLineData = {
+              ownStake: ownStakeRatio.multipliedBy(100).toFixed(2),
+              delegation: BigNumberJs(1).minus(ownStakeRatio).multipliedBy(100).toFixed(2),
+            };
+
+            // allocation
+            const unallocatedStakeRatio = BigNumberJs(runnerAllocationData?.left || 0).div(
+              runnerAllocationData?.total || 0,
+            );
+            const allocatedStakeRatio = BigNumberJs(1).minus(unallocatedStakeRatio);
+            const allocationRenderLineData = {
               unAllocation: unallocatedStakeRatio.multipliedBy(100).toFixed(2),
-              ownStake: allocatedStakeRatio.multipliedBy(100).multipliedBy(ownStakeRatio).toFixed(2),
-              delegation: allocatedStakeRatio
-                .multipliedBy(100)
-                .multipliedBy(BigNumberJs(1).minus(ownStakeRatio))
-                .toFixed(2),
+              allocation: allocatedStakeRatio.multipliedBy(100).toFixed(2),
+            };
+
+            // last era rewards
+            const lastTotalRewards = BigNumberJs(indexerLastEraRewardsInfo.data?.indexerReward?.amount || 0);
+            const lastAllocationRewards = BigNumberJs(
+              indexerLastEraRewardsInfo.data?.indexerAllocationRewards?.aggregates?.sum?.reward || 0,
+            );
+            const lastQueryRewards = lastTotalRewards.minus(lastAllocationRewards);
+            const lastAllocationBurnt = BigNumberJs(
+              indexerLastEraRewardsInfo.data?.indexerAllocationRewards?.aggregates?.sum?.burnt || 0,
+            );
+            const totalRatio = lastTotalRewards.plus(lastAllocationBurnt);
+            const rewardsRenderLineData = {
+              allocationRewards: lastAllocationRewards.div(totalRatio).multipliedBy(100).toFixed(2),
+              queryRewards: lastQueryRewards.div(totalRatio).multipliedBy(100).toFixed(2),
+              burnt: lastAllocationBurnt.div(totalRatio).multipliedBy(100).toFixed(2),
             };
 
             return (
@@ -303,143 +337,106 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                 {sortedDesc && <div className={styles.desc}>{sortedDesc}</div>}
                 <div className={styles.info}>
                   <SubqlCard
-                    title={
-                      <div style={{ width: '100%' }}>
-                        <div className="flex">
-                          <Typography>Current Total Stake</Typography>
-                          <Tooltip title="This is the total staked amount right now. This includes SQT that has been delegated to you">
-                            <InfoCircleOutlined style={{ marginLeft: 4, color: 'var(--sq-gray500)' }} />
-                          </Tooltip>
-                          <span style={{ flex: 1 }}></span>
+                    title={'Current Total Stake'}
+                    tooltip="This is the total staked amount right now. This includes SQT that has been delegated to you"
+                    className={styles.totalStake}
+                    titleExtra={BalanceLayout({
+                      mainBalance: BigNumberJs(sortedIndexerData?.totalStake.current.toString()).toString(),
+                      secondaryBalance: BigNumberJs(sortedIndexerData?.totalStake.after?.toString() || '0').toString(),
+                    })}
+                  >
+                    <div
+                      style={{
+                        width: '100%',
+                        height: 12,
+                        margin: '12px 0 20px 0',
+                        overflow: 'hidden',
+                        display: 'flex',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: `${renderLineData.ownStake}%`,
+                          height: '100%',
+                          background: 'var(--sq-blue600)',
+                        }}
+                      ></div>
+                      <div
+                        style={{
+                          width: `${renderLineData.delegation}%`,
+                          height: '100%',
+                          background: 'var(--sq-success)',
+                        }}
+                      ></div>
+                    </div>
 
-                          <DoStake
-                            onSuccess={async () => {
-                              await sortedIndexer?.refresh?.();
-                            }}
-                          ></DoStake>
-                        </div>
-
-                        <div>
-                          {BalanceLayout({
-                            mainBalance: BigNumberJs(sortedIndexerData?.totalStake.current.toString()).toString(),
-                            secondaryBalance: BigNumberJs(
-                              sortedIndexerData?.totalStake.after?.toString() || '0',
-                            ).toString(),
-                          })}
-                        </div>
-
-                        <div
-                          style={{
-                            width: '100%',
-                            height: 12,
-                            borderRadius: 4,
-                            margin: '12px 0 20px 0',
-                            overflow: 'hidden',
-                            display: 'flex',
-                            alignItems: 'center',
-                          }}
-                        >
+                    <div className={styles.stakeInfo}>
+                      {[
+                        {
+                          name: 'Own Stake',
+                          color: 'var(--sq-blue600)',
+                          currentBalance: formatNumber(
+                            BigNumberJs(sortedIndexerData?.ownStake.current.toString()).toString(),
+                          ),
+                          afterBalance: formatNumber(
+                            BigNumberJs(sortedIndexerData?.ownStake.after?.toString() || '0').toString(),
+                          ),
+                        },
+                        {
+                          name: 'Total Delegation',
+                          color: 'var(--sq-success)',
+                          currentBalance: formatNumber(
+                            BigNumberJs(sortedIndexerData?.totalDelegations.current.toString()).toString(),
+                          ),
+                          afterBalance: formatNumber(
+                            BigNumberJs(sortedIndexerData?.totalDelegations.after?.toString() || '0').toString(),
+                          ),
+                        },
+                      ].map((item) => {
+                        return (
                           <div
                             style={{
-                              width: `${renderLineData.ownStake}%`,
-                              height: '100%',
-                              background: 'var(--sq-blue600)',
+                              display: 'flex',
+                              alignItems: 'baseline',
+                              width: '100%',
+                              justifyContent: 'space-between',
                             }}
-                          ></div>
-                          <div
-                            style={{
-                              width: `${renderLineData.delegation}%`,
-                              height: '100%',
-                              background: 'var(--sq-success)',
-                            }}
-                          ></div>
-                          <div
-                            style={{
-                              width: `${renderLineData.unAllocation}%`,
-                              height: '100%',
-                              background: 'var(--sq-warning)',
-                            }}
-                          ></div>
-                        </div>
-
-                        <div className={styles.stakeInfo}>
-                          {[
-                            {
-                              name: 'Own Stake',
-                              color: 'var(--sq-blue600)',
-                              currentBalance: formatNumber(
-                                BigNumberJs(sortedIndexerData?.ownStake.current.toString()).toString(),
-                              ),
-                              afterBalance: formatNumber(
-                                BigNumberJs(sortedIndexerData?.ownStake.after?.toString() || '0').toString(),
-                              ),
-                            },
-                            {
-                              name: 'Total Delegation',
-                              color: 'var(--sq-success)',
-                              currentBalance: formatNumber(
-                                BigNumberJs(sortedIndexerData?.totalDelegations.current.toString()).toString(),
-                              ),
-                              afterBalance: formatNumber(
-                                BigNumberJs(sortedIndexerData?.totalDelegations.after?.toString() || '0').toString(),
-                              ),
-                            },
-                            {
-                              name: isOverAllocate ? 'Over Allocated' : 'Unallocated Stake',
-                              color: 'var(--sq-warning)',
-                              currentBalance: formatNumber(runnerAllocationData?.left || '0'),
-                              afterBalance: formatNumber(runnerAllocationData?.left || '0'),
-                              isOverAllocate: isOverAllocate,
-                            },
-                          ].map((item) => {
-                            return (
+                            key={item.name}
+                          >
+                            <Typography
+                              variant="medium"
+                              style={{ marginRight: 4, display: 'flex', alignItems: 'baseline' }}
+                            >
                               <div
                                 style={{
-                                  display: 'flex',
-                                  alignItems: 'baseline',
-                                  width: '100%',
-                                  justifyContent: 'space-between',
+                                  width: '12px',
+                                  height: '12px',
+                                  borderRadius: 2,
+                                  background: item.color,
+                                  marginRight: 4,
                                 }}
-                                key={item.name}
-                              >
-                                <Typography
-                                  variant="medium"
-                                  style={{ marginRight: 4, display: 'flex', alignItems: 'baseline' }}
-                                >
-                                  <div
-                                    style={{
-                                      width: '12px',
-                                      height: '12px',
-                                      borderRadius: 2,
-                                      background: item.color,
-                                      marginRight: 4,
-                                    }}
-                                  ></div>
-                                  {item.name}
-                                </Typography>
-                                <div className="col-flex" style={{ alignItems: 'flex-end' }}>
-                                  <Typography variant="medium">
-                                    {item.currentBalance} {TOKEN}
-                                    {item.isOverAllocate && (
-                                      <Tooltip title="Your current allocation amount exceeds your available stake. Please adjust to align with your available balance. ">
-                                        <WarningOutlined style={{ marginLeft: 4, color: 'var(--sq-error)' }} />
-                                      </Tooltip>
-                                    )}
-                                  </Typography>
-                                  {!item.isOverAllocate && (
-                                    <Typography type="secondary" variant="small">
-                                      {item.afterBalance} {TOKEN}
-                                    </Typography>
-                                  )}
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    }
-                    className={styles.totalStake}
-                  ></SubqlCard>
+                              ></div>
+                              {item.name}
+                            </Typography>
+                            <div className="col-flex" style={{ alignItems: 'flex-end' }}>
+                              <Typography variant="medium">
+                                {item.currentBalance} {TOKEN}
+                              </Typography>
+                              <Typography type="secondary" variant="small">
+                                {item.afterBalance} {TOKEN}
+                              </Typography>
+                            </div>
+                          </div>
+                        );
+                      })}
+                      <DoStake
+                        onSuccess={async () => {
+                          await sortedIndexer?.refresh?.();
+                        }}
+                      ></DoStake>
+                    </div>
+                  </SubqlCard>
 
                   <SubqlCard
                     title={
@@ -456,7 +453,181 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                     })}
                     style={{ boxShadow: 'none', marginBottom: 24, flex: 1 }}
                   >
-                    <div className="flex">
+                    <div
+                      style={{
+                        width: '100%',
+                        height: 12,
+                        margin: '12px 0 20px 0',
+                        overflow: 'hidden',
+                        display: 'flex',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: `${allocationRenderLineData.allocation}%`,
+                          height: '100%',
+                          background: 'var(--sq-blue600)',
+                        }}
+                      ></div>
+                      <div
+                        style={{
+                          width: `${allocationRenderLineData.unAllocation}%`,
+                          height: '100%',
+                          background: 'var(--sq-warning)',
+                        }}
+                      ></div>
+                    </div>
+
+                    <div className={styles.stakeInfo}>
+                      {[
+                        {
+                          name: 'Allocated Stake',
+                          color: 'var(--sq-blue600)',
+                          currentBalance: formatNumber(BigNumberJs(runnerAllocationData?.used || 0).toString()),
+                        },
+                        {
+                          name: isOverAllocate ? 'Over Allocated' : 'Unallocated Stake',
+                          color: 'var(--sq-warning)',
+                          currentBalance: formatNumber(BigNumberJs(runnerAllocationData?.left || 0).toString()),
+                          isOverAllocate: isOverAllocate,
+                        },
+                      ].map((item) => {
+                        return (
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'baseline',
+                              width: '100%',
+                              justifyContent: 'space-between',
+                            }}
+                            key={item.name}
+                          >
+                            <Typography
+                              variant="medium"
+                              style={{ marginRight: 4, display: 'flex', alignItems: 'baseline' }}
+                            >
+                              <div
+                                style={{
+                                  width: '12px',
+                                  height: '12px',
+                                  borderRadius: 2,
+                                  background: item.color,
+                                  marginRight: 4,
+                                }}
+                              ></div>
+                              {item.name}
+                            </Typography>
+                            <div className="col-flex" style={{ alignItems: 'flex-end' }}>
+                              <Typography variant="medium">
+                                {item.currentBalance} {TOKEN}
+                                {item.isOverAllocate && (
+                                  <Tooltip title="Your current allocation amount exceeds your available stake. Please adjust to align with your available balance. ">
+                                    <WarningOutlined style={{ marginLeft: 4, color: 'var(--sq-error)' }} />
+                                  </Tooltip>
+                                )}
+                              </Typography>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </SubqlCard>
+
+                  <SubqlCard
+                    title={'Last Era Project Rewards'}
+                    tooltip="Rewards earned by all projects in the previous era, distributed between Delegators and the Node Operator"
+                    titleExtra={BalanceLayout({
+                      mainBalance: formatNumber(formatSQT(lastTotalRewards.toString())),
+                    })}
+                    style={{ boxShadow: 'none', marginBottom: 24, flex: 1 }}
+                  >
+                    <div
+                      style={{
+                        width: '100%',
+                        height: 12,
+                        margin: '12px 0 20px 0',
+                        overflow: 'hidden',
+                        display: 'flex',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: `${rewardsRenderLineData.allocationRewards}%`,
+                          height: '100%',
+                          background: 'var(--sq-blue600)',
+                        }}
+                      ></div>
+                      <div
+                        style={{
+                          width: `${rewardsRenderLineData.queryRewards}%`,
+                          height: '100%',
+                          background: 'var(--sq-success)',
+                        }}
+                      ></div>
+                      <div
+                        style={{
+                          width: `${rewardsRenderLineData.burnt}%`,
+                          height: '100%',
+                          background: 'var(--sq-warning)',
+                        }}
+                      ></div>
+                    </div>
+
+                    <div className={styles.stakeInfo}>
+                      {[
+                        {
+                          name: 'Allocation Rewards',
+                          color: 'var(--sq-blue600)',
+                          currentBalance: formatNumber(formatSQT(lastAllocationRewards.toString() || '0').toString()),
+                        },
+                        {
+                          name: 'Query Rewards',
+                          color: 'var(--sq-success)',
+                          currentBalance: formatNumber(formatSQT(lastQueryRewards.toString() || '0').toString()),
+                        },
+                        {
+                          name: 'Burned Rewards',
+                          color: 'var(--sq-warning)',
+                          currentBalance: formatNumber(formatSQT(lastAllocationBurnt.toString() || '0').toString()),
+                        },
+                      ].map((item) => {
+                        return (
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'baseline',
+                              width: '100%',
+                              justifyContent: 'space-between',
+                            }}
+                            key={item.name}
+                          >
+                            <Typography
+                              variant="medium"
+                              style={{ marginRight: 4, display: 'flex', alignItems: 'baseline' }}
+                            >
+                              <div
+                                style={{
+                                  width: '12px',
+                                  height: '12px',
+                                  borderRadius: 2,
+                                  background: item.color,
+                                  marginRight: 4,
+                                }}
+                              ></div>
+                              {item.name}
+                            </Typography>
+                            <div className="col-flex" style={{ alignItems: 'flex-end' }}>
+                              <Typography variant="medium">
+                                {item.currentBalance} {TOKEN}
+                              </Typography>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {/* <div className="flex">
                       <Typography>Total Allocation Rewards</Typography>
                       <span style={{ flex: 1 }}></span>
                       <Typography>
@@ -469,7 +640,7 @@ export const OwnDeployments: React.FC<Props> = ({ indexer, emptyList, desc }) =>
                         )}{' '}
                         {TOKEN}
                       </Typography>
-                    </div>
+                    </div> */}
                   </SubqlCard>
                 </div>
                 {!indexerDeployments.loading && (!indexerDepolymentsData || indexerDepolymentsData.length === 0) ? (

--- a/src/pages/indexer/MyStaking/DoStake/DoStake.tsx
+++ b/src/pages/indexer/MyStaking/DoStake/DoStake.tsx
@@ -146,50 +146,40 @@ export const DoStake: React.FC<{ onSuccess: () => void }> = ({ onSuccess }) => {
       const actions = [stakeButton, unstakeButton];
 
       return (
-        <>
-          <Dropdown
-            menu={{
-              items: [
-                {
-                  label: (
-                    <Button type="text" style={{ padding: 0, background: 'transparent' }} size="small">
-                      Stake more
-                    </Button>
-                  ),
-                  key: 1,
-                  onClick: () => {
-                    if (modalRef.current) {
-                      modalRef.current.showModal(stakeButton.key);
-                    }
-                    stakeButton.onClick?.();
-                  },
-                },
-                {
-                  label: (
-                    <Tooltip title={isMaxUnstakeZero ? t('indexer.unStakeTooltip') : undefined}>
-                      <Button
-                        size="small"
-                        type="text"
-                        disabled={isMaxUnstakeZero}
-                        style={{ padding: 0, background: 'transparent' }}
-                        onClick={() => {
-                          if (modalRef.current) {
-                            modalRef.current.showModal(unstakeButton.key);
-                          }
-                          unstakeButton.onClick?.();
-                        }}
-                      >
-                        Unstake
-                      </Button>
-                    </Tooltip>
-                  ),
-                  key: 2,
-                },
-              ],
+        <div
+          style={{
+            display: 'flex',
+          }}
+        >
+          <Button
+            type="primary"
+            onClick={() => {
+              if (modalRef.current) {
+                modalRef.current.showModal(stakeButton.key);
+              }
+              stakeButton.onClick?.();
             }}
+            shape="round"
+            size="large"
+            style={{ flex: 1 }}
           >
-            <OutlineDot></OutlineDot>
-          </Dropdown>
+            Stake More
+          </Button>
+          <Button
+            ghost
+            type="primary"
+            onClick={() => {
+              if (modalRef.current) {
+                modalRef.current.showModal(unstakeButton.key);
+              }
+              unstakeButton.onClick?.();
+            }}
+            shape="round"
+            size="large"
+            style={{ flex: 1, marginLeft: 16 }}
+          >
+            Unstake
+          </Button>
           <TransactionModal
             ref={modalRef}
             text={modalText}
@@ -217,7 +207,7 @@ export const DoStake: React.FC<{ onSuccess: () => void }> = ({ onSuccess }) => {
               }
             }}
           />
-        </>
+        </div>
       );
     },
   });

--- a/src/utils/numberFormatters.ts
+++ b/src/utils/numberFormatters.ts
@@ -91,7 +91,11 @@ export function formatNumber(num: number | string, precision = 2) {
   }
 
   if (+num < 1) {
-    return (+num).toFixed(precision);
+    const result = (+num).toFixed(precision);
+    if (+result === 0 && +num !== 0) {
+      return `~${result}`;
+    }
+    return result;
   }
 
   return num;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4523,14 +4523,14 @@
   resolved "https://registry.npmjs.org/@subql/contract-sdk/-/contract-sdk-1.0.3.tgz#02af55c7778d13eb87d4dac41518268a00632d34"
   integrity sha512-ONJkxNL86YyLFTt26+dagnsZQUXV1of/ncoFTKXt+jX6Gj+X26U74k6cJ4x7gBCP8U61VPFdxD4D5TJmaKw7zQ==
 
-"@subql/network-clients@1.1.1-3":
-  version "1.1.1-3"
-  resolved "https://registry.npmjs.org/@subql/network-clients/-/network-clients-1.1.1-3.tgz#c99c4368799fe885cb7b215d3eb76eff6efd355a"
-  integrity sha512-fNB6OoiekdyYnIR2f9NFHzP9r4u1/AdWT/UvMMHrOPEWjedwvfsAbXhjdG4qmPCUFGzXtZ2JtXee9bNXU+pBLA==
+"@subql/network-clients@1.1.1-4":
+  version "1.1.1-4"
+  resolved "https://registry.yarnpkg.com/@subql/network-clients/-/network-clients-1.1.1-4.tgz#78ae911a60af9e04b02718730a1c724be2f07205"
+  integrity sha512-kxvKGCE+YE1F2S4rUtmIfCa5tiulExebVLaQXc68M7qe9ZzS3Rr9biKAJHyKQXoDbvZyv+DgZzyPij2OaiLm6Q==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
     "@subql/network-config" "1.1.2-0"
-    "@subql/network-query" "1.1.2-6"
+    "@subql/network-query" "1.1.2-12"
     axios "^0.27.2"
     buffer "^6.0.3"
     cross-fetch "^3.1.5"
@@ -4551,13 +4551,6 @@
   version "1.1.2-12"
   resolved "https://registry.yarnpkg.com/@subql/network-query/-/network-query-1.1.2-12.tgz#378a7b8a527ab1b9b735748777c0c5134a609d6f"
   integrity sha512-viVnVcY0zvd9fLEWBBqwxxru2rgVeJyfSfSgfbdbf3iQ0nsNaQcvIOwf43MJieYeugbPsVwqfwx19+KOuRUy5w==
-  dependencies:
-    graphql "^16.5.0"
-
-"@subql/network-query@1.1.2-6":
-  version "1.1.2-6"
-  resolved "https://registry.npmjs.org/@subql/network-query/-/network-query-1.1.2-6.tgz#7dfa68e38a34898530beef16b32b9affb9e352cd"
-  integrity sha512-bkquEa5/eUHqMJX8ljDee0PWLkvvKUgGokE4wv2KMeQK40cOeSv77HM73bJDg6vd1E3NWiQJuSO2SApnsyH73w==
   dependencies:
     graphql "^16.5.0"
 


### PR DESCRIPTION
## Description

- Improve fetch operator's capacity & metadata.
- Speed up load all operators.
- Adjust page size and support sort by capacity for All Operators page 
- Adjust my-projects page, show burnt rewards(all/projects), show last era rewards instead of total rewards.
- Enhance UI of my-projects.
- Enhance error tip.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvements (ie: code cleaning or remove unused codes or performance issue)

