### PR TITLE
chore: fix invalid CSS margin value causing warnings

### DIFF
--- a/src/components/AlertBanner/AlertBanner.tsx
+++ b/src/components/AlertBanner/AlertBanner.tsx
@@ -17,7 +17,7 @@ const AlertBanner: FC<{ center?: boolean }> = ({ center = false }) => {
           background: 'var(--sq-blue600)',
           border: 'none',
           padding: isMobile ? '14px' : '14px 80px',
-          margin: center ? '0 auto' : '',
+          margin: center ? '0 auto' : undefined,
           width: isMobile ? '100%' : center ? '1440px' : '100%',
           position: 'relative',
           zIndex: 1,


### PR DESCRIPTION
## Description

empty string in `margin` was causing CSS warnings. changed it to `undefined` to clean things up.

## Test cases:

* checked that no warnings appear in the console when rendering components with margin.
* verified layout remains the same.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Improvements (ie: code cleaning or remove unused codes or performance issue)

## UI Changes

no visible UI changes.
layout stays the same.