### PR TITLE
fix: IPFS decoding for browser environment

### DIFF
--- a/src/containers/IPFS.ts
+++ b/src/containers/IPFS.ts
@@ -77,5 +77,6 @@ function useIPFSImpl(
 export const { useContainer: useIPFS, Provider: IPFSProvider } = createContainer(useIPFSImpl, { displayName: 'IPFS' });
 
 export const decodeIpfsRaw = <T>(raw: Uint8Array): T => {
-  return JSON.parse(Buffer.from(raw).toString('utf8'));
+  const text = new TextDecoder('utf-8').decode(raw);
+  return JSON.parse(text) as T;
 };


### PR DESCRIPTION
## Description

I updated `decodeIpfsRaw` to use `TextDecoder('utf-8').decode(raw)` instead of `Buffer.from(raw).toString('utf8')`.
This fixes compatibility in browser environments where `Buffer` is not available.

## Test cases:

* Verified that decoding works in Node.js as before.
* Verified that decoding works in a browser environment without errors.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## UI Changes

* None

